### PR TITLE
Git merged needs in twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,6 @@ jobs:
           build_and_push
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
-    needs:
-      - build_and_push
     steps:
        - name: Checkout
          uses: actions/checkout@v2


### PR DESCRIPTION
When the merge happend the NEEDS statement was duplicated

