### PR TITLE
Pass SHA to Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
           push: true
+          build_args: BASE_IMAGE_SHA=${{ github.event.client_payload.parent_sha }}
   deploy:
     name: Deliver to Development
     needs:
@@ -54,7 +55,7 @@ jobs:
              mkdir -p $HOME/.terraform.d/plugins/linux_amd64
              wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
              chmod +x ${{ env.CF_PROVIDER_DIR }}
-   
+
        - name: Terraform Init
          run: |
              cd terraform/paas && pwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG RAILSAPP=dfedigital/get-into-teaching-web:latest
-FROM $RAILSAPP
+# Pull from $BASE_IMAGE_SHA passed as build-arg or use latest if empty
+ARG BASE_IMAGE_SHA=latest
+FROM dfedigital/get-into-teaching-web:${BASE_IMAGE_SHA}
 
 COPY content app/views/content
 COPY assets public/assets


### PR DESCRIPTION
### Context
The pipeline always builds from the latest docker image from the app repository. Instead it should use the reference passed in the event.

### Changes proposed in this pull request
Pass the SHA as build-arg to the docker build, and use latest as default if empty.

### Guidance to review
Try:
```
docker build -t git-content-test --build-arg  .
```
And:
```
docker build -t git-content-test --build-arg BASE_IMAGE_SHA=sha-ff34ec8 .
```