### PR TITLE
Added the build time inside the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,4 @@ COPY assets public/assets
 
 ARG CONTENT_SHA
 RUN echo "${CONTENT_SHA}" > /etc/get-into-teaching-content-sha
+RUN date -u -Iseconds > /etc/get-into-teaching-content-build-time


### PR DESCRIPTION
### JIRA ticket number

GITPB-519

### Context

The static files held within this repo should be cacheable but to set appropriate headers the last modified time is required.

### Changes proposed in this pull request

1. Embed the last modified time within the container - uses UTC, format contains time zone and is easily recognised by Rails' `Time.parse`



