### PR TITLE
Changed Location of CF Provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ env:
   CONTAINER: get-into-teaching-app
   DOMAIN: london.cloudapps.digital
   CF_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  CF_PROVIDER_URL: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.3/terraform-provider-cloudfoundry_v0.12.3_linux_amd64
+
 jobs:
   deploy:
     name: Build and deploy
@@ -84,7 +86,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
             mkdir -p $HOME/.terraform.d/plugins/linux_amd64
-            wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
+            wget -O ${{ env.CF_PROVIDER_DIR }} ${{ env.CF_PROVIDER_URL }}
             chmod +x ${{ env.CF_PROVIDER_DIR }}
 
       - name: Wait for any previous runs to complete

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 env:
   DOCKERHUB_REPOSITORY: dfedigital/get-into-teaching-frontend
   CF_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  CF_PROVIDER_URL: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.3/terraform-provider-cloudfoundry_v0.12.3_linux_amd64
 
 jobs:
   deploy_qa:
@@ -48,7 +49,7 @@ jobs:
        - name: Install Terraform CloudFoundry Provider
          run: |
              mkdir -p $HOME/.terraform.d/plugins/linux_amd64
-             wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
+             wget -O ${{ env.CF_PROVIDER_DIR }} ${{ env.CF_PROVIDER_URL }}
              chmod +x ${{ env.CF_PROVIDER_DIR }}
    
        - name: Terraform Init

--- a/.github/workflows/ur.yml
+++ b/.github/workflows/ur.yml
@@ -6,6 +6,7 @@ on:
 env:
   DOCKERHUB_REPOSITORY: dfedigital/get-into-teaching-frontend
   CF_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+  CF_PROVIDER_URL: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.3/terraform-provider-cloudfoundry_v0.12.3_linux_amd64
 
 jobs:
   deploy_qa:
@@ -48,7 +49,7 @@ jobs:
        - name: Install Terraform CloudFoundry Provider
          run: |
              mkdir -p $HOME/.terraform.d/plugins/linux_amd64
-             wget -O ${{ env.CF_PROVIDER_DIR }} https://github.com/cloudfoundry-community/terraform-provider-cf/releases/latest/download/terraform-provider-cloudfoundry_linux_amd64
+             wget -O ${{ env.CF_PROVIDER_DIR }} ${{ env.CF_PROVIDER_URL }}
              chmod +x ${{ env.CF_PROVIDER_DIR }}
    
        - name: Terraform Init


### PR DESCRIPTION
Terraform community provider team have renamed their output
This has broken our pipelines
so we have pointed the provider to the new name in the pipelines files

