### PR TITLE
No need for CF provider with Statuscake deployment

### DIFF
--- a/.github/workflows/statuscake.yml
+++ b/.github/workflows/statuscake.yml
@@ -2,10 +2,6 @@ name: Deploy Status Cake (Beta Test)
 on:
   workflow_dispatch:
 
-env:
-  SC_PROVIDER_DIR: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
-  SC_PROVIDER_URL: https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.3/terraform-provider-cloudfoundry_v0.12.3_linux_amd64
-
 jobs:
   deploy:
     name: Status Cake Configuration
@@ -17,12 +13,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v1
         with:
            terraform_version: 0.12.29
-
-      - name: Install Terraform CloudFoundry Provider
-        run: |
-            mkdir -p $HOME/.terraform.d/plugins/linux_amd64
-            wget -O ${{ env.SC_PROVIDER_DIR }} ${{ env.SC_PROVIDER_URL }}
-            chmod +x ${{ env.SC_PROVIDER_DIR }}
 
       - name: Terraform Init
         run: |


### PR DESCRIPTION
When Deploying statuscake it does not use cloud foundry, so the terraform provider can be removed for this workflow. It was left in more by accident than design

