### PR TITLE
Production Work Flow Tagging

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -22,6 +22,16 @@ jobs:
       run:
         shell: bash
     steps:
+       - name: Check Tag is a Release
+         run: |
+               rval=$(curl -s -X GET https://api.github.com/repos/DFE-Digital/get-into-teaching-content/releases/tags/${{ github.event.inputs.tags }} | jq -r ".message")
+               if [ "${rval}" = "Not Found" ]
+               then
+                   echo "Tag ${{ github.event.inputs.tags }} cannot be found in releases"
+                   exit 1
+               fi
+               exit 0
+
        - name: Checkout
          uses: actions/checkout@v2
          with:
@@ -31,16 +41,11 @@ jobs:
          id: sha
          run: echo ::set-output name=short::$(git rev-parse --short HEAD )
 
-       - name: Get parent SHA 
-         run: |
-           echo ::set-env name=parent_sha::$(docker run dfedigital/get-into-teaching-web:latest cat /etc/get-into-teaching-app-sha)
-
        - name: Set new docker image version
          run: |
-           docker_image_tag="sha-${{ steps.sha.outputs.short }}-${parent_sha}"
+           docker_image_tag="sha-${{ steps.sha.outputs.short }}"
            echo ::set-env name=docker_image_tag::${docker_image_tag}
            echo "Content SHA: ${{ steps.sha.outputs.short }}"
-           echo "Parent SHA: ${parent_sha}"
            echo "New version tag: ${docker_image_tag}"
 
        - name: Wait for any previous runs to complete
@@ -83,40 +88,40 @@ jobs:
              TF_VAR_RAILS_MASTER_KEY:  "${{ secrets.RAILS_MASTER_KEY_PRODUCTION }}"
              TF_VAR_RAILS_ENV:         "production"
 
-       - name: Terraform Apply
-         run: |
-             cd terraform/paas && pwd
-             terraform apply -auto-approve plan
-         env:
-             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
-             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
-             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+#      - name: Terraform Apply
+#        run: |
+#            cd terraform/paas && pwd
+#            terraform apply -auto-approve plan
+#        env:
+#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
+#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
+#            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
 
-       - name: Smoke tests
-         run: |
-             tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${parent_sha}" "${{ steps.sha.outputs.short }}"
-         env:
-             HTTPAUTH_PASSWORD: ""
-             HTTPAUTH_USERNAME: ""
+#      - name: Smoke tests
+#        run: |
+#            tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${parent_sha}" "${{ steps.sha.outputs.short }}"
+#        env:
+#            HTTPAUTH_PASSWORD: ""
+#            HTTPAUTH_USERNAME: ""
 
-       - name: Create Sentry release
-         if: success()
-         uses: getsentry/action-release@v1.0.0
-         env:
-           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-         with:
-           environment: production
+#      - name: Create Sentry release
+#        if: success()
+#        uses: getsentry/action-release@v1.0.0
+#        env:
+#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+#          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+#        with:
+#          environment: production
 
-       - name: Slack Notification
-         if: failure()
-         uses: rtCamp/action-slack-notify@master
-         env:
-           SLACK_CHANNEL: getintoteaching_tech
-           SLACK_COLOR: '#3278BD'
-           SLACK_ICON: https://github.com/rtCamp.png?size=48
-           SLACK_MESSAGE: ':disappointed_relieved: Pipeline Failure carrying out job ${{github.job}} :disappointed_relieved:'
-           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#      - name: Slack Notification
+#        if: failure()
+#        uses: rtCamp/action-slack-notify@master
+#        env:
+#          SLACK_CHANNEL: getintoteaching_tech
+#          SLACK_COLOR: '#3278BD'
+#          SLACK_ICON: https://github.com/rtCamp.png?size=48
+#          SLACK_MESSAGE: 'Pipeline Failure carrying out job ${{github.job}}'
+#          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
                

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,7 +1,13 @@
 ---  
 name: Release to Production
 on: 
-    workflow_dispatch:
+   repository_dispatch:
+   workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Release Tag'
+        required: true
+        default: 'master'
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/get-into-teaching-frontend
@@ -18,10 +24,12 @@ jobs:
     steps:
        - name: Checkout
          uses: actions/checkout@v2
+         with:
+            ref: "${{ github.event.inputs.tags }}"
 
        - name: Get Short SHA
          id: sha
-         run: echo ::set-output name=short::$(git rev-parse --short $GITHUB_SHA)
+         run: echo ::set-output name=short::$(git rev-parse --short HEAD )
 
        - name: Get parent SHA 
          run: |

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -86,40 +86,40 @@ jobs:
              TF_VAR_RAILS_MASTER_KEY:  "${{ secrets.RAILS_MASTER_KEY_PRODUCTION }}"
              TF_VAR_RAILS_ENV:         "production"
 
-#      - name: Terraform Apply
-#        run: |
-#            cd terraform/paas && pwd
-#            terraform apply -auto-approve plan
-#        env:
-#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
-#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
-#            ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
+       - name: Terraform Apply
+         run: |
+             cd terraform/paas && pwd
+             terraform apply -auto-approve plan
+         env:
+             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
+             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
+             ARM_ACCESS_KEY:           "${{ secrets.PROD_ARM_ACCESS_KEY  }}"
 
-#      - name: Smoke tests
-#        run: |
-#            tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${parent_sha}" "${{ steps.sha.outputs.short }}"
-#        env:
-#            HTTPAUTH_PASSWORD: ""
-#            HTTPAUTH_USERNAME: ""
+       - name: Smoke tests
+         run: |
+             tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${parent_sha}" "${{ steps.sha.outputs.short }}"
+         env:
+             HTTPAUTH_PASSWORD: ""
+             HTTPAUTH_USERNAME: ""
 
-#      - name: Create Sentry release
-#        if: success()
-#        uses: getsentry/action-release@v1.0.0
-#        env:
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-#          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-#        with:
-#          environment: production
+       - name: Create Sentry release
+         if: success()
+         uses: getsentry/action-release@v1.0.0
+         env:
+           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+         with:
+           environment: production
 
-#      - name: Slack Notification
-#        if: failure()
-#        uses: rtCamp/action-slack-notify@master
-#        env:
-#          SLACK_CHANNEL: getintoteaching_tech
-#          SLACK_COLOR: '#3278BD'
-#          SLACK_ICON: https://github.com/rtCamp.png?size=48
-#          SLACK_MESSAGE: 'Pipeline Failure carrying out job ${{github.job}}'
-#          SLACK_TITLE: 'Failure: ${{ github.workflow }}'
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+       - name: Slack Notification
+         if: failure()
+         uses: rtCamp/action-slack-notify@master
+         env:
+           SLACK_CHANNEL: getintoteaching_tech
+           SLACK_COLOR: '#3278BD'
+           SLACK_ICON: https://github.com/rtCamp.png?size=48
+           SLACK_MESSAGE: 'Pipeline Failure carrying out job ${{github.job}}'
+           SLACK_TITLE: 'Failure: ${{ github.workflow }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
                

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,13 +1,11 @@
 ---  
 name: Release to Production
 on: 
-   repository_dispatch:
    workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Release Tag'
-        required: true
-        default: 'master'
+     inputs:
+       tags:
+         description: 'Release Tag'
+         required: true
 
 env:
   DOCKERHUB_REPOSITORY: dfedigital/get-into-teaching-frontend

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -97,7 +97,7 @@ jobs:
 
        - name: Smoke tests
          run: |
-             tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${parent_sha}" "${{ steps.sha.outputs.short }}"
+             tests/confidence/healthcheck.sh  "get-into-teaching-app-prod" "${{ steps.sha.outputs.short }}"
          env:
              HTTPAUTH_PASSWORD: ""
              HTTPAUTH_USERNAME: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 ---  
 name: Release to test
 on: 
+   repository_dispatch:
+   workflow_dispatch:
    release:
      types:  [edited, created]
 env:
@@ -18,10 +20,12 @@ jobs:
     steps:
        - name: Checkout
          uses: actions/checkout@v2
+         with:
+               ref: "t.57"
 
        - name: Get Short SHA
          id: sha
-         run: echo ::set-output name=short::$(git rev-parse --short $GITHUB_SHA)
+         run: echo ::set-output name=short::$(git rev-parse --short HEAD )
 
        - name: Get parent SHA 
          run: |
@@ -75,21 +79,29 @@ jobs:
              TF_VAR_RAILS_MASTER_KEY:  "${{ secrets.RAILS_MASTER_KEY_PREPROD }}"
              TF_VAR_RAILS_ENV:         "preprod"
 
-       - name: Terraform Apply
-         run: |
-             cd terraform/paas && pwd
-             terraform apply -auto-approve plan
-         env:
-             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
-             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
-             ARM_ACCESS_KEY:           "${{ secrets.TEST_ARM_ACCESS_KEY  }}"
+#      - name: Terraform Apply
+#        run: |
+#            cd terraform/paas && pwd
+#            terraform apply -auto-approve plan
+#        env:
+#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
+#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
+#            ARM_ACCESS_KEY:           "${{ secrets.TEST_ARM_ACCESS_KEY  }}"
 
-       - name: Smoke tests
-         run: |
-             tests/confidence/healthcheck.sh  "get-into-teaching-app-test" "${parent_sha}" "${{ steps.sha.outputs.short }}"
-         env:
-             HTTPAUTH_PASSWORD: "${{ secrets.HTTPAUTH_PASSWORD }}"
-             HTTPAUTH_USERNAME: "${{ secrets.HTTPAUTH_USERNAME }}"
+#      - name: Smoke tests
+#        run: |
+#            tests/confidence/healthcheck.sh  "get-into-teaching-app-test" "${parent_sha}" "${{ steps.sha.outputs.short }}"
+#        env:
+#            HTTPAUTH_PASSWORD: "${{ secrets.HTTPAUTH_PASSWORD }}"
+#            HTTPAUTH_USERNAME: "${{ secrets.HTTPAUTH_USERNAME }}"
+
+       - name: Update Dockerhub with Release Tag
+         uses: zenato/docker-action@master
+         with:
+             username: ${{ secrets.DOCKERHUB_USERNAME }}
+             password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+             repository: ${{ env.DOCKERHUB_REPOSITORY }}
+             tag: "Steve"
 
        - name: Create Sentry release
          if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,11 @@ jobs:
          id: sha
          run: echo ::set-output name=short::$(git rev-parse --short HEAD )
 
-       - name: Get parent SHA 
-         run: |
-           echo ::set-env name=parent_sha::$(docker run dfedigital/get-into-teaching-web:latest cat /etc/get-into-teaching-app-sha)
-
        - name: Set new docker image version
          run: |
-           docker_image_tag="sha-${{ steps.sha.outputs.short }}-${parent_sha}"
+           docker_image_tag="sha-${{ steps.sha.outputs.short }}"
            echo ::set-env name=docker_image_tag::${docker_image_tag}
            echo "Content SHA: ${{ steps.sha.outputs.short }}"
-           echo "Parent SHA: ${parent_sha}"
            echo "New version tag: ${docker_image_tag}"
 
        - name: Wait for any previous runs to complete
@@ -79,24 +74,25 @@ jobs:
              TF_VAR_RAILS_MASTER_KEY:  "${{ secrets.RAILS_MASTER_KEY_PREPROD }}"
              TF_VAR_RAILS_ENV:         "preprod"
 
-#      - name: Terraform Apply
-#        run: |
-#            cd terraform/paas && pwd
-#            terraform apply -auto-approve plan
-#        env:
-#            TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
-#            TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
-#            ARM_ACCESS_KEY:           "${{ secrets.TEST_ARM_ACCESS_KEY  }}"
+       - name: Terraform Apply
+         run: |
+             cd terraform/paas && pwd
+             terraform apply -auto-approve plan
+         env:
+             TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
+             TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"
+             ARM_ACCESS_KEY:           "${{ secrets.TEST_ARM_ACCESS_KEY  }}"
 
-#      - name: Smoke tests
-#        run: |
-#            tests/confidence/healthcheck.sh  "get-into-teaching-app-test" "${parent_sha}" "${{ steps.sha.outputs.short }}"
-#        env:
-#            HTTPAUTH_PASSWORD: "${{ secrets.HTTPAUTH_PASSWORD }}"
-#            HTTPAUTH_USERNAME: "${{ secrets.HTTPAUTH_USERNAME }}"
+       - name: Smoke tests
+         run: |
+             tests/confidence/healthcheck.sh  "get-into-teaching-app-test" "${{ steps.sha.outputs.short }}"
+         env:
+             HTTPAUTH_PASSWORD: "${{ secrets.HTTPAUTH_PASSWORD }}"
+             HTTPAUTH_USERNAME: "${{ secrets.HTTPAUTH_USERNAME }}"
 
        - name: Update Dockerhub with Release Tag
-         uses: zenato/docker-action@master
+         run: |
+           docker tag "Steve"  ${{ env.DOCKERHUB_REPOSITORY }} 
          with:
              username: ${{ secrets.DOCKERHUB_USERNAME }}
              password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}

--- a/tests/confidence/healthcheck.sh
+++ b/tests/confidence/healthcheck.sh
@@ -5,8 +5,7 @@
 ###
 ### Input parameters ( not validated )
 ### 1 URL
-### 2 APPLICATION SHA
-### 3 CONTENT SHA
+### 2 CONTENT SHA
 ###
 ### Returns
 ### 1 on failure
@@ -14,8 +13,7 @@
 ###
 #################################################################################################
 URL=${1}
-APP_SHA=${2}
-CONTENT_SHA=${3}
+CONTENT_SHA=${2}
 
 #URL="get-into-teaching-app-dev"
 #APP_SHA="de1bb0b"
@@ -40,15 +38,6 @@ else
 	echo "HTTP Status is Healthy"
 
         json=$(curl ${AUTHORITY}  -s -X GET ${FULL_URL})
-
-        sha=$( echo ${json} | jq -r .app_sha)
-        if [ "${sha}" != "${APP_SHA}"  ] 
-        then
-		echo "APPLICATION SHA (${sha}) is not ${APP_SHA} "
-        	rval=1
-        else
-                echo "APPLICATION SHA is correct"
-        fi
 
         sha=$( echo ${json} | jq -r .content_sha)
         if [ "${sha}" != "${CONTENT_SHA}"  ] 


### PR DESCRIPTION
### Problem
When releasing to Production we need to be able to re-release older versions. This means we need to pass in a tag.

However, we do not want to release tags that have not been tested so, we have a check that ensures a tag has been part of a release.

### Considerations
The Content is deployed by content change, or sometimes the parent image causes a rebuild.  Because a Release is only on the CONTENT repository, I am not aware of the parent SHA, which is often used to make the docker tag. Though the last version of the PARENT/CONTENT Sha combination is the same image as the one with the CONTENT sha 
**example:**

**"sha-7b9a685                         sha256:6ced5c4b9d57563e6b65087b2243a3cc1affc3338f1860d195573300cfd2d4de"
"sha-7b9a685-sha-b3f1d1f.   sha256:6ced5c4b9d57563e6b65087b2243a3cc1affc3338f1860d195573300cfd2d4de"**
"sha-7b9a685-sha-78a54c5 sha256:9bd1dfa364d591a253485563089836913a7e4a1280c5a85d78a08b8e9dfccf68"
"sha-7b9a685-sha-84a66ed sha256:f8e171c7fd00481ee08d424a35c2c4a5afe6d29b2ffff7fb59f532f10a6e107e"
"sha-7b9a685-sha-4e46fc6 sha256:0586112771a220f0588a23be82302199b6261f6c5902fc597a346cd5c4dcb3ff"
"sha-7b9a685-sha-edd590f sha256:cf273bbf4e231bf5fb3ef8d76d36f97b80ed87f59bb64a854999afe138431bbd"
"sha-7b9a685-sha-99337c3 sha256:15c0bb8533376acb351aa7075b44bf6545578288ad7e03282602f72c47b39815"

### Testing
I have tested this by:

Commenting out all the code that does anything ( terraform, sentry and slack )
Running the action from the branch devops/workflows/sha-options with a tag of "master" . As expected Failed
Running the action from the branch devops/workflows/sha-options with a tag of "BETA-1.0". As expected Passed
Remove comments

