### PR TITLE
Switch Apply for teacher training links from QA to Live

### DIFF
--- a/content/finance-guidance.html.erb
+++ b/content/finance-guidance.html.erb
@@ -621,7 +621,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://qa.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/guidance.html.erb
+++ b/content/guidance.html.erb
@@ -1885,7 +1885,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://qa.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/guidance_archive.html
+++ b/content/guidance_archive.html
@@ -1858,7 +1858,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://qa.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/steps-to-become-a-teacher/v2-index
+++ b/content/steps-to-become-a-teacher/v2-index
@@ -139,13 +139,13 @@ backlink: "../"
   <div id="collapsable-content-4" class="collapsable">
     <p>
       Once you have decided that you want to train to become a teacher and have the necessary qualifications you’ll need to 
-      <a href="https://qa.apply-for-teacher-training.education.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">prepare your application</a> using the following steps:
+      <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">prepare your application</a> using the following steps:
     </p>
     <ul>
       <li><span><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">choose your course</a></span></li>
       <li><span>write a personal statement</span></li>
       <li><span>get two references</span></li>
-      <li><span><a href="https://qa.apply-for-teacher-training.education.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">apply for teacher training</a></span></li>
+      <li><span><a href="https://www.apply-for-teacher-training.service.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">apply for teacher training</a></span></li>
     </ul>
   </div>
 

--- a/content/ways-to-train-guidance.html.erb
+++ b/content/ways-to-train-guidance.html.erb
@@ -902,7 +902,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://qa.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">


### PR DESCRIPTION
Some links were aimed at Apply's QA environment, they have been switched to their Live one.
