### PR TITLE
Change to the Apply service's official link

### DIFF
--- a/content/finance-guidance.html.erb
+++ b/content/finance-guidance.html.erb
@@ -621,7 +621,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/guidance.html.erb
+++ b/content/guidance.html.erb
@@ -1239,12 +1239,12 @@
 	Apply for teacher training
 </h2>
 <p>
-	You can apply for a training place via <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS Teacher Training</a>, or by using a new GOV.UK service called <a href="https://www.apply-for-teacher-training.education.gov.uk/candidate">Apply for teacher training</a>.
+	You can apply for a training place via <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS Teacher Training</a>, or by using a new GOV.UK service called <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training</a>.
 </p>
 <p>Apply for teacher training will eventually replace <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS</a>, but for now, the new service is limited to certain providers. 
 </p>
 <p>
-	View a list of <a href="https://www.apply-for-teacher-training.education.gov.uk/candidate/providers">training providers and courses available</a> through the new GOV.UK service.
+	View a list of <a href="https://www.gov.uk/apply-for-teacher-training">training providers and courses available</a> through the new GOV.UK service.
 </p>
 <p>
 	By October 2021, all candidates will apply to all courses and all providers
@@ -1885,7 +1885,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/guidance_archive.html
+++ b/content/guidance_archive.html
@@ -1236,12 +1236,12 @@
 	Apply for teacher training
 </h2>
 <p>
-	You can apply for a training place via <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS Teacher Training</a>, or by using a new GOV.UK service called <a href="https://www.apply-for-teacher-training.education.gov.uk/candidate">Apply for teacher training</a>.
+	You can apply for a training place via <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS Teacher Training</a>, or by using a new GOV.UK service called <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training</a>.
 </p>
 <p>Apply for teacher training will eventually replace <a href="https://www.ucas.com/postgraduate/teacher-training/ucas-teacher-training-apply-and-track">UCAS</a>, but for now, the new service is limited to certain providers. 
 </p>
 <p>
-	View a list of <a href="https://www.apply-for-teacher-training.education.gov.uk/candidate/providers">training providers and courses available</a> through the new GOV.UK service.
+	View a list of <a href="https://www.gov.uk/apply-for-teacher-training">training providers and courses available</a> through the new GOV.UK service.
 </p>
 <p>
 	By October 2021, all candidates will apply to all courses and all providers
@@ -1858,7 +1858,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">

--- a/content/steps-to-become-a-teacher.md
+++ b/content/steps-to-become-a-teacher.md
@@ -129,16 +129,16 @@ navigation: 20
     <div id="collapsable-content-5" class="steps-content collapsable" data-target="accordion.content">
       <p>
         Once you have decided that you want to train to become a teacher and have the necessary qualifications you’ll need to 
-        <a href="https://www.apply-for-teacher-training.service.gov.uk/" target="_blank" rel="noopener noreferrer">prepare your application<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>using the following steps:
+        <a href="https://www.gov.uk/apply-for-teacher-training" target="_blank" rel="noopener noreferrer">prepare your application<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>using the following steps:
       </p>
   <ul>
         <li><span><span><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses" target="_blank" rel="noopener noreferrer">choose your course<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></span></span></li>
         <li><span><span>write a personal statement</span></span></li>
         <li><span><span>get two references</span></span></li>
-        <li>apply for teacher training either through <a href="https://www.ucas.com/postgraduate/teacher-training/how-to-apply/">UCAS Teacher Training <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>, or by using the <span><span><a href="https://www.apply-for-teacher-training.service.gov.uk/" target="_blank" rel="noopener noreferrer">Apply for teacher training GOV.UK service <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></span></span></li>
+        <li>apply for teacher training either through <a href="https://www.ucas.com/postgraduate/teacher-training/how-to-apply/">UCAS Teacher Training <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>, or by using the <span><span><a href="https://www.gov.uk/apply-for-teacher-training" target="_blank" rel="noopener noreferrer">Apply for teacher training GOV.UK service <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></span></span></li>
       </ul>
   <p>Apply for teacher training will eventually replace UCAS, but for now, the new service is limited to certain providers.</p>
-  <p>View a list of <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate/providers">training providers and courses available <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> through the new GOV.UK service.</p>
+  <p>View a list of <a href="https://www.gov.uk/apply-for-teacher-training">training providers and courses available <span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> through the new GOV.UK service.</p>
   
   <p>You can get help preparing your application by signing up to the <a href="https://beta-adviser-getintoteaching.education.gov.uk/">Get an adviser</a> service.</p>
     </div>

--- a/content/steps-to-become-a-teacher/v2-index
+++ b/content/steps-to-become-a-teacher/v2-index
@@ -139,13 +139,13 @@ backlink: "../"
   <div id="collapsable-content-4" class="collapsable">
     <p>
       Once you have decided that you want to train to become a teacher and have the necessary qualifications you’ll need to 
-      <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">prepare your application</a> using the following steps:
+      <a href="https://www.gov.uk/apply-for-teacher-training"  target="_blank" rel="noopener noreferrer">prepare your application</a> using the following steps:
     </p>
     <ul>
       <li><span><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">choose your course</a></span></li>
       <li><span>write a personal statement</span></li>
       <li><span>get two references</span></li>
-      <li><span><a href="https://www.apply-for-teacher-training.service.gov.uk/candidate"  target="_blank" rel="noopener noreferrer">apply for teacher training</a></span></li>
+      <li><span><a href="https://www.gov.uk/apply-for-teacher-training"  target="_blank" rel="noopener noreferrer">apply for teacher training</a></span></li>
     </ul>
   </div>
 

--- a/content/ways-to-train-guidance.html.erb
+++ b/content/ways-to-train-guidance.html.erb
@@ -902,7 +902,7 @@
                     href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a>
                 </li>
                 <li class="gem-c-related-navigation__link">
-                    <a href="https://www.apply-for-teacher-training.service.gov.uk/candidate">Apply for teacher training in England</a>
+                    <a href="https://www.gov.uk/apply-for-teacher-training">Apply for teacher training in England</a>
                 </li>
 
    <li class="gem-c-related-navigation__link">


### PR DESCRIPTION
Previously we were using their service.gov.uk one but they are
available on a more-friendly gov.uk/apply-for-teacher-training one too
