### PR TITLE
New hook for event dispatch

### DIFF
--- a/.github/workflows/app-repo-changed.yml
+++ b/.github/workflows/app-repo-changed.yml
@@ -1,0 +1,49 @@
+name: Update base image
+on:
+  repository_dispatch:
+
+env:
+  BASE_IMAGE: dfedigital/get-into-teaching-web
+
+jobs:
+  updatebase:
+    name: Update base docker image
+    runs-on: ubuntu-latest
+    if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Get parent SHA if triggered from app pipeline
+        id: parent-sha
+        run: |
+          echo ::set-output name=full::${{ github.event.client_payload.parent_sha }}
+          echo ::set-output name=short::$(${{ github.event.client_payload.parent_sha }} | cut -c -7)
+
+      - name: Derive base image
+        id: docker-image
+        run: |-
+          echo ::set-output name=image::${{ env.BASE_IMAGE }}:sha-${{ steps.parent-sha.outputs.short }}
+
+      - name: New base image
+        run: |-
+          echo "DOCKER IMAGE: '${{ steps.docker-image.outputs.image }}'"
+
+      - name: Update Dockerfile
+        run: |-
+          sed -i "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~" Dockerfile
+
+      - name: Commit
+        run: |
+          git config user.name "GiT Workflow Bot"
+          git config user.email "<>"
+          git add Dockerfile
+          git commit -m "Updated base image to sha-${{ steps.parent-sha.outputs.short }}
+
+          ${{ steps.docker-image.outputs.image }}"
+
+      - name: Commit debug
+        run: git show HEAD
+
+      - name: Push branch
+        run: git push origin master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build and Deploy
+
 on:
-  repository_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
   push:
@@ -52,25 +52,7 @@ jobs:
 
       - name: Get Short SHA
         id: sha
-        run: echo ::set-output name=short::$(git rev-parse --short $GITHUB_SHA)
-
-      - name: Get parent SHA if triggered from app pipeline
-        if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
-        run: |
-          echo ::set-env name=parent_sha::${{ github.event.client_payload.parent_sha }}
-
-      - name: Get parent SHA if not triggered from app pipeline
-        if: env.GITHUB_EVENT_NAME != 'repository_dispatch'
-        run: |
-          echo ::set-env name=parent_sha::$(docker run dfedigital/get-into-teaching-web:latest cat /etc/get-into-teaching-app-sha)
-
-      - name: Set new docker image version
-        run: |
-          docker_image_tag="sha-${{ steps.sha.outputs.short }}-${parent_sha}"
-          echo ::set-env name=docker_image_tag::${docker_image_tag}
-          echo "Content SHA: ${{ steps.sha.outputs.short }}"
-          echo "Parent SHA: ${parent_sha}"
-          echo "New version tag: ${docker_image_tag}"
+        run: echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
 
       - name: Build only
         uses: docker/build-push-action@v1
@@ -81,11 +63,10 @@ jobs:
           repository: ${{ env.DOCKERHUB_REPOSITORY }}
           always_pull: true
           add_git_labels: true
-          tags: ${{ env.docker_image_tag }}
           tag_with_ref: true
           tag_with_sha: true
           push: false
-          build_args: APP_SHA=${{ env.parent_sha }},CONTENT_SHA=${{ steps.sha.outputs.short }}
+          build_args: CONTENT_SHA=${{ steps.sha.outputs.short }}
 
       - name: Build and push to DockerHub
         uses: docker/build-push-action@v1
@@ -96,11 +77,10 @@ jobs:
           repository: ${{ env.DOCKERHUB_REPOSITORY }}
           always_pull: true
           add_git_labels: true
-          tags: ${{ env.docker_image_tag }}
           tag_with_ref: true
           tag_with_sha: true
           push: true
-          build_args: APP_SHA=${{ env.parent_sha }},CONTENT_SHA=${{ steps.sha.outputs.short }}
+          build_args: CONTENT_SHA=${{ steps.sha.outputs.short }}
 
       - uses: hashicorp/setup-terraform@v1
         with:
@@ -129,7 +109,7 @@ jobs:
             cd terraform/paas && pwd
             terraform plan -var-file=dev.env.tfvars -out plan
         env:
-              TF_VAR_paas_app_docker_image: ${{env.DOCKERHUB_REPOSITORY}}:${{ env.docker_image_tag }}
+              TF_VAR_paas_app_docker_image: ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }}
               ARM_ACCESS_KEY:           "${{ secrets.DEV_ARM_ACCESS_KEY  }}"
               TF_VAR_user:              "${{ secrets.GOVUKPAAS_USERNAME  }}"
               TF_VAR_password:          "${{ secrets.GOVUKPAAS_PASSWORD  }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG APP_SHA
-FROM dfedigital/get-into-teaching-web:${APP_SHA}
+FROM dfedigital/get-into-teaching-web:sha-5fe203c
 
 COPY content app/views/content
 COPY assets public/assets

--- a/Dockerfile.experiment
+++ b/Dockerfile.experiment
@@ -1,9 +1,0 @@
-ARG APP_SHA
-FROM dfedigital/get-into-teaching-web:${APP_SHA}
-
-COPY content app/views/content
-COPY assets public/assets
-
-ARG CONTENT_SHA
-RUN echo "${CONTENT_SHA}" > /etc/get-into-teaching-content-sha
-RUN date -u -Iseconds > /etc/get-into-teaching-content-build-time


### PR DESCRIPTION
### JIRA ticket number

N/a

### Context

Currently only changes to the content repo will result in a release of a new image through to production. Changes in the app repo will be ignored at the point of deploying to TEST and PROD environments.

This is caused by TEST and PROD only having access to the Git SHA for the Content repo. This SHA is insufficient to correctly identify the appropriate docker image so a docker image with only the Content SHA is used. When the build occurs a new image is built but with the same docker image tag (because it uses only the Content SHA and that has not changed).

When terraform comes to deploy, because the docker image tag has not changed, it will succeed but not actually pull the new image. This is in effect the same issue as when pipelines try to deploy `:latest`

### Changes proposed in this pull request

1. Added new workflow for the repository dispatch event - this will update the
   base image in the master branch, which will in turn trigger the existing build and deploy workflow

2. The build workflow no longer fires on event dispatch

3. The 'parent-sha' tagging has been removed - this information is embedded with
   in the Dockerfile. We can now just rely upon the default behaviour of the
   docker build action with a single image:sha-XXXXXXX

4. Replaced the use of git rev-parse --short. The docker GH Action always just
   crops to 7 chars rather than using Git's own behaviour so we should align
   with that.


