### PR TITLE
Remove the update base image steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build and Deploy
 
 on:
-  repository_dispatch:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
   push:
@@ -43,40 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: turnstyle 
     steps:
-      - name: EVENT NAME
-        run: echo "Event name is '${{ env.GITHUB_EVENT_NAME }}'"
-
-      - name: Get parent SHA if triggered from app pipeline
-        id: parent-sha
-        if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
-        run: |
-          echo ::set-output name=full::${{ github.event.client_payload.parent_sha }}
-          echo ::set-output name=short::$(echo "${{ github.event.client_payload.parent_sha }}" | cut -c -7)
-
-      - name: Derive base image
-        id: docker-image
-        if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
-        run: |-
-          echo ::set-output name=image::${{ env.BASE_IMAGE }}:sha-${{ steps.parent-sha.outputs.short }}
-
       - name: Check out the repo
         uses: actions/checkout@v2
-
-      - name: Update Dockerfile
-        if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
-        run: |-
-          sed -i "s~FROM .*~FROM ${{ steps.docker-image.outputs.image }}~" Dockerfile
-
-      - name: Commit and push
-        if: env.GITHUB_EVENT_NAME == 'repository_dispatch'
-        run: |
-          git config user.name "GiT Workflow Bot"
-          git config user.email "<>"
-          git add Dockerfile
-          git commit -m "Updated base image to sha-${{ steps.parent-sha.outputs.short }}
-
-          ${{ steps.docker-image.outputs.image }}"
-          git push
 
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@master


### PR DESCRIPTION
This didn't work as intended and we're now doing the update from outside of the
repository.