### PR TITLE
Added global frontmatter and updated README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM dfedigital/get-into-teaching-web:sha-0b1f757
 
+COPY config/frontmatter.yml config
 COPY content app/views/content
 COPY assets public/assets
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ Image layered on top of the application one.
 
 The combined image is then deployed through to GovUK PAAS via Github Actions.
 
+## Frontmatter
+
+How markdown content is rendered is controlled from the Frontmatter - that YAML
+definition at the start of the markdown file. 
+
+There is also a global frontmatter config which is merged in with the per-page 
+front matter. This can be used for things like global acronym definitions.
+
+This can be found at `config/frontmatter.yml`
+
+### Acronyms
+
+Acronyms are replaced with an HTML tag allowing the user to hover to view the
+acronym definition.
+
+```YAML
+---
+accronyms:
+  DFE: Department for Education
+  VAT: Value added tag
+---
+```
+
 ## DevOps
 
 ### Accessibility Scanning

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ acronym definition.
 
 ```YAML
 ---
-accronyms:
+acronyms:
   DFE: Department for Education
   VAT: Value added tag
 ---

--- a/config/frontmatter.yml
+++ b/config/frontmatter.yml
@@ -1,0 +1,3 @@
+acronyms:
+  QTS: Qualified Teacher Status
+  NQT: Newly Qualified Teacher


### PR DESCRIPTION
### Trello card

https://trello.com/c/0J164eou

### Context

The content editors should be able to control global definitions of acronyms to expand.

### Changes proposed in this pull request

1. Added a global frontmatter file.
2. Updated Dockerfile to include this file when building the Docker image
3. Updated README.md to describe this



