### PR TITLE
Filename and URL changes

### DIFF
--- a/content/financial-support-for-teacher-training.html.erb
+++ b/content/financial-support-for-teacher-training.html.erb
@@ -2,13 +2,13 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <style type="text/css" id="alertifyCSS">.alertify-logs>*{padding:12px 24px;color:#fff;box-shadow:0 2px 5px 0 rgba(0,0,0,.2);border-radius:1px}.alertify-logs>*,.alertify-logs>.default{background:rgba(0,0,0,.8)}.alertify-logs>.error{background:rgba(244,67,54,.8)}.alertify-logs>.success{background:rgba(76,175,80,.9)}.alertify{position:fixed;background-color:rgba(0,0,0,.3);left:0;right:0;top:0;bottom:0;width:100%;height:100%;z-index:2}.alertify.hide{opacity:0;pointer-events:none}.alertify,.alertify.show{box-sizing:border-box;transition:all .33s cubic-bezier(.25,.8,.25,1)}.alertify,.alertify *{box-sizing:border-box}.alertify .dialog{padding:12px}.alertify .alert,.alertify .dialog{width:100%;margin:0 auto;position:relative;top:50%;-webkit-transform:translateY(-50%);transform:translateY(-50%)}.alertify .alert>*,.alertify .dialog>*{width:400px;max-width:95%;margin:0 auto;text-align:center;padding:12px;background:#fff;box-shadow:0 2px 4px -1px rgba(0,0,0,.14),0 4px 5px 0 rgba(0,0,0,.098),0 1px 10px 0 rgba(0,0,0,.084)}.alertify .alert .msg,.alertify .dialog .msg{padding:12px;margin-bottom:12px;margin:0;text-align:left}.alertify .alert input:not(.form-control),.alertify .dialog input:not(.form-control){margin-bottom:15px;width:100%;font-size:100%;padding:12px}.alertify .alert input:not(.form-control):focus,.alertify .dialog input:not(.form-control):focus{outline-offset:-2px}.alertify .alert nav,.alertify .dialog nav{text-align:right}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button),.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button){background:transparent;box-sizing:border-box;color:rgba(0,0,0,.87);position:relative;outline:0;border:0;display:inline-block;-webkit-align-items:center;-ms-flex-align:center;-ms-grid-row-align:center;align-items:center;padding:0 6px;margin:6px 8px;line-height:36px;min-height:36px;white-space:nowrap;min-width:88px;text-align:center;text-transform:uppercase;font-size:14px;text-decoration:none;cursor:pointer;border:1px solid transparent;border-radius:2px}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover{background-color:rgba(0,0,0,.05)}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus{border:1px solid rgba(0,0,0,.1)}.alertify .alert nav button.btn,.alertify .dialog nav button.btn{margin:6px 4px}.alertify-logs{position:fixed;z-index:1}.alertify-logs.bottom,.alertify-logs:not(.top){bottom:16px}.alertify-logs.left,.alertify-logs:not(.right){left:16px}.alertify-logs.left>*,.alertify-logs:not(.right)>*{float:left;-webkit-transform:translateZ(0);transform:translateZ(0);height:auto}.alertify-logs.left>.show,.alertify-logs:not(.right)>.show{left:0}.alertify-logs.left>*,.alertify-logs.left>.hide,.alertify-logs:not(.right)>*,.alertify-logs:not(.right)>.hide{left:-110%}.alertify-logs.right{right:16px}.alertify-logs.right>*{float:right;-webkit-transform:translateZ(0);transform:translateZ(0)}.alertify-logs.right>.show{right:0;opacity:1}.alertify-logs.right>*,.alertify-logs.right>.hide{right:-110%;opacity:0}.alertify-logs.top{top:0}.alertify-logs>*{box-sizing:border-box;transition:all .4s cubic-bezier(.25,.8,.25,1);position:relative;clear:both;-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-perspective:1000;perspective:1000;max-height:0;margin:0;padding:0;overflow:hidden;opacity:0;pointer-events:none}.alertify-logs>.show{margin-top:12px;opacity:1;max-height:1000px;padding:12px;pointer-events:auto}</style>
-  <meta property="og:description" content="Ways to train to become a teacher">
-  <meta property="og:title" content="Ways to train to become a teacher">
-  <meta property="og:url" content="https://beta-getintoteaching.education.gov.uk/ways-to-train-guidance">
+  <meta property="og:description" content="Become a teacher in England">
+  <meta property="og:title" content="Become a teacher in England">
+  <meta property="og:url" content="https://beta-getintoteaching.education.gov.uk/guidance">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="GOV.UK">
   <meta name="twitter:card" content="summary">
-  <meta name="description" content="Ways to train to become a teacher">
+  <meta name="description" content="Become a teacher in England">
   <meta name="govuk:taxon-slugs" content="become-a-teacher-in-england">
   <meta name="govuk:taxon-slug" content="become-a-teacher-in-england">
   <meta name="govuk:taxon-ids" content="2682bef9-0963-43e3-8610-30b31ec1c4d0,56b78356-c7bf-4460-8775-d04b590ec7ca">
@@ -43,7 +43,7 @@
     <%- end -%>
   </script>
   <title lang="en">
-      Ways to train to become a teacher
+     Financial support for teacher training
   </title>
   <!--[if gt IE 8]><!-->
   <link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/govuk-template-ec01c15a0e8793975bcaf519e4eb3ec0d68a99610c6b262fa7a1b3c7f76f6176.css">
@@ -230,7 +230,7 @@
     <span class="govuk-caption-xl gem-c-title__context">
       Guidance
     </span>
-  <h1 class="gem-c-title__text gem-c-title__text--long" id="top">Ways to train to become a teacher</h1>
+  <h1 class="gem-c-title__text gem-c-title__text--long" id="top">Financial support for teacher training</h1>
 </div>
   </div>
 
@@ -283,44 +283,30 @@
         <nav class="gem-c-contents-list  gem-c-contents-list--no-underline " role="navigation" data-module="track-click" aria-label="Contents">
           <h2 class="gem-c-contents-list__title">Contents</h2>
           <ol class="gem-c-contents-list__list">
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+		  <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
               <a class="gem-c-contents-list__link govuk-link" href="#introduction">Introduction</a>
             </li>
             <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#what-youll-need-to-work-as-a-teacher">What you’ll need to work as a teacher</a>
-		    </li>
+              <a class="gem-c-contents-list__link govuk-link" href="#bursaries">Bursaries</a>
+            </li>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#scholarships">Scholarships</a>
+            </li>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#tuition-fee-maintenance-loans">Tuition fee and maintenance loans</a>
+            </li>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link " href="#parents-and-carers">Parents and carers - extra financial support</a>
+            </li>
+	    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link " href="#disabled-students">Disabled students - extra financial support</a>
+            </li>
+		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link " href="#find-train-to-teach-event">Find a Train To Teach event near you</a>
+		  </li>  
 		  <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#gaining-qts">Gaining Qualified Teacher Status</a>
-            </li>
-		   
-		  
-		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#training-providers">Types of teacher training provider</a>
-            </li>
-		   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#salaried">Salaried teacher training courses</a>
-            </li>
-		
-		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#things-to-consider">Things to consider before you apply</a>
-            </li>
-		
-		   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#teaching-children-with-special-educational-needs-and-or-disabilities-SEND">Teaching children with special educational needs and disabilities (SEND)</a>
-            </li>
-		     <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#training-to-teach-if-you-have-a-disability">Training to teach if you have a disability</a>
-		</li>
-		   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#high-potential">High potential candidates, career changers and researchers</a>
-            </li>
-           
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link " href="#get-a-job-in-teaching">Get a job in teaching</a>
-            </li>
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
               <a class="gem-c-contents-list__link govuk-link " href="#contact-and-support">Contact and support</a>
-            </li>
+		  </li>
           </ol>
         </nav>
       </div>
@@ -328,538 +314,219 @@
       
       <div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
         <div class="govspeak">
-          <h2 id="introduction">Introduction</h2>
           
 
 
 
-<h2 id="what-youll-need-to-work-as-a-teacher">
-	What you’ll need to work as a teacher
-</h2>
+
+
+<h2 id="introduction">Introduction</h2>
 <p>
-	To work as a qualified teacher in state schools in England, you’ll need
-	Qualified Teacher Status (QTS).
-</p>
-		
-<p>
-	QTS allows you to teach as a qualified teacher in state-maintained schools and non-maintained special schools in England. It may also allow you to teach in other parts of the UK. 
+	The level of financial support you get will depend on the subject you choose and the way you train to become a teacher.
 </p>
 <p>
-	There is information available about teaching in <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a>, <a href="https://teachinscotland.scot/">Scotland</a> and <a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a>.
+	There are several types of funding that may all be available to you, depending on your eligibility:
 </p>
+        <ul>
+	<li>a bursary or scholarship</li>
+	<li>tuition fee and maintenance loans</li>
+	<li>extra financial support if you're a parent, a carer, or you have a disability</li>	
+        </ul>
+
+<p>For advice about bursaries or scholarships, you can <a href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">chat online</a> or call Freephone 0800 389 2501 between 8.30am and 5pm, Monday to Friday.</p>
 
 <p>
-	Undergraduate teacher training leading to QTS can take up to 4 years.
-</p>
-<p>
-	Graduate teacher training leading to QTS typically takes one year of full-time study. Some providers offer part-time study, which typically take 2 years.
-</p>
-<p>
-	Once you’ve gained your QTS, you can apply for jobs as a
-	newly-qualified teacher (NQT).
-</p>
-<p>
-	NQTs do a further 'induction programme' in school as a paid and qualified teacher, which allows them to build on their initial teacher training.
+	Please note that alternative funding is in place to train as an Early Years teacher, which leads to achieving Early Years Teacher Status (EYTS).
 </p>
 		
-	<h3 id="assessment-only-candidates-already-working-in-school">
-	Assessment only (candidates already working in school)
-	</h3>
-<p>
-	If you’re an unqualified teacher with 2 years’ experience, you can be assessed over a maximum of 12 weeks to gain Qualified Teacher Status (QTS).
-</p>
-<p>
-	Although you may not need to take a formal teacher training course, you must
-	meet the eligibility requirements for teacher training - which includes a degree, and GCSEs (or a standard equivalent) in English, maths, and science for primary school teaching.
-</p>
-		
-<h2 id="gaining-qts">
-	Gaining Qualified Teacher Status
-</h2>
-		<h3>PGCE with QTS</h3>
-<p>
-	A PGCE (postgraduate certificate in education) with QTS gives you an academic qualification as well as QTS.  Many PGCE courses include credits that count towards a Master’s degree.
-</p>
-<P>
-	A PGCE may allow you to teach in some other countries. If you’re planning to teach overseas, you should always check what’s needed in the country you’d like to teach in.
-</P>
-		<h3>PGDE with QTS</h3>
-<p>
-	Some providers offer a PGDE (postgraduate diploma in education) with QTS. In some cases these courses offer more credits towards
-	a Master’s degree than PGCE courses.
-</p>
+<h2 id="bursaries">Bursaries</h2>
+<p>A bursary is a tax-free sum of money awarded to high quality graduates who meet eligibility criteria and train to teach in certain subjects. You may be eligible for a bursary or a scholarship but you cannot receive both. If you receive one, you will not have to pay it back.</p> 
 
-<H4>
-	Further education (PGCE or PGDE without QTS)
-</H4>
-<p>
-	To teach further education you do not need QTS. Instead you can study for a PGCE
-	or PGDE without QTS. These courses are also eligible for candidates without a
-	degree.
-</p>
-		
-		
-		
-<h3 id="find-postgraduate-teacher-training">
-	Find postgraduate teacher training
-</h3>
-	<p>
-	All primary and secondary teacher training courses on <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a> lead to QTS.
-        </p>	
-		
-<p>
-	Use <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
-	postgraduate teacher training courses</a> to search and compare
-	government-approved teacher training providers in your area.
-</p>
-
-<p>
-	You can also search for ‘further education’ courses leading to a post-compulsory
-	education and training qualification (PCET). You do not need a degree to apply
-	for courses leading to a PCET.
-</p>
-		
-<h2 id="salaried">
-	Salaried teacher training courses
-</h2>
-
-<p>
-	Under some circumstances, you can train as a teacher ‘on the job’. On these courses, you will:
-</p>
+<p>They are only available in the following subjects:</p>
 <ul>
-	<li>earn a salary
-	<li>pay no student fees for training towards QTS</li>
+<li>chemistry, computing, maths, physics - £24,000</li>
+<li>classics, languages - £10,000</li>
+<li>biology - £7,000</li>
 </ul>
 
-<p>
-	There are 3 options available:
-</p>
+<h3>Eligibility</h3>
+
+<p>Bursaries are awarded to candidates:</p>
 <ul>
-	<li>School Direct (salaried)</li>
-	<li>Postgraduate teaching apprenticeships</li>
-	<li>High Potential Initial Teacher Training Programme</li>
-</ul>
-	<p>On these courses you’ll be paid and taxed as an unqualified teacher. The salary awarded will differ between schools – you should check the salary with the school before you apply.
-</p>
-<p>
-	These courses do not offer bursaries, scholarships or student
-	finance. There are usually no course fees to pay.
-</p>
-<p>
-	Both School Direct (salaried) and postgraduate apprenticeship courses will lead to QTS.  If you choose to do a postgraduate teaching apprenticeship, you’ll also have to sit an ‘end point assessment’ (EPA). 
-</p>
-<p>
-	Select ‘only salaried courses’ in <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training</a> to find local courses.
-</p>
-		
-<h2 id="training-providers">
-	Types of teacher training provider
-</h2>
-<p>
-	You can do your teacher training on a course run by a university, an individual
-	school, or a partnership of schools (sometimes called a SCITT, standing for
-	‘school-centred initial teacher training’).
-</p>
-<p>
-	Although the type of institution (school or university) running the course will
-	differ, the content of the course will meet national guidelines on teacher
-	training.
-</p>
-<p>
-	The primary and secondary teacher training courses listed on <a
-		href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
-	postgraduate teacher training</a> all lead to QTS or PGCE/PGDE plus QTS.
-</p>
-<p>
-	The majority of postgraduate teacher training courses are made up of:
-</p>
-<ul>
-	<li>academic study of the theory of teaching (also known as ‘pedagogy’)
-	<li>hands-on experience in the classroom</li>
-</ul>
-<p>
-	The course typically lasts a year (3 school terms) and training will usually take place:
-</p>
-<ul>
-	<li>at your training provider's main site
-	<li>in school placements organised by your provider</li>
-</ul>
-<p>
-	Details of course structure and location will vary between training providers –
-	you can research specific courses on <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses" target="_blank" rel="noopener noreferrer">Find postgraduate teacher training</a>.
-</p>
-<p>
-	When you’re researching training providers, bear in mind:
-</p>
-<ul>
-	<li>location – you will need to be able to travel to your academic learning
-		location as well as your placement schools
-	<li>reputation – check Ofsted’s report on your training provider for more detail
-	<li>competition for entry – some providers are tougher than others
-	<li>special academic requirements for entry – check the training provider
-		listing in <a
-			href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
-		postgraduate teacher training</a> to see what class of degree, for example, the
-		provider asks for
-	<li>size of institution – would you be happier in a large university campus, or
-		in a smaller local school setting?
-	</li>
-</ul>
-<p>
-	You can use<a
-		href="https://www.gov.uk/find-postgraduate-teacher-training-courses"> Find
-	postgraduate teacher training</a> to find and compare a shortlist of training
-	providers located near to you.
-</p>
-		
-		
-<h2 id="things-to-consider">
-	Things to consider before you apply
-</h2>
-		
-		
-<h3 id="choose-an-age-group">
-	Choose an age group
-</h3>
-<p>
-	You can train to teach:
-</p>
-<ul>
-	<li>under-fives (also known as ‘early years’)</li>
-	<li>primary school children</li>
-	<li>primary school with a specialism (for example, English, modern languages or
-		science)</li>
-	<li>secondary school age children (you’ll need to specialise in a subject)</li>
-	<li>further education (14 to adult)</li>
-</ul>
-<p>
-	Use <a
-		href="https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2">Find postgraduate teacher training</a> to see the full list of options.
-</p>
-<p>
-	Or you could arrange to spend time in school to <a href="https://schoolexperience.education.gov.uk/">get experience of different age groups.</a>
-</p>
-<h3 id="teaching-under-fives">
-	Teaching under-fives
-</h3>
-<p>
-	If you choose to teach under-fives, you’ll need to apply for a specialist
-	teacher training course called Early Years Initial Teacher Training (EYITT).
-</p>
-<p>
-	At the end of the course, you’ll gain Early Years Teacher Status and will be
-	qualified to teach under-fives only.
-</p>
-<div role="note" aria-label="Information" class="application-notice info-notice">
-  <p>Please note these courses do not lead to Qualified Teacher Status (QTS).</p>
-</div>
-<p>
-	<a
-		href="https://www.gov.uk/government/publications/early-years-initial-teacher-training-itt-providers-and-school-direct-early-years-lead-organisations/early-years-initial-teacher-training-itt-providers-and-school-direct-lead-organisations">Browse a list of training providers offering Early Years Teacher Training</a>
-</p>
-<p>
-	EYITT courses are eligible for bursaries, scholarships and student finance. Some are also salaried.
-</p>
-<p>
-	Undergraduate courses:
-</p>
-<ul>
-	<li>take 3 to 4 years of full-time study and lead to a degree in an early</li>
-		childhood-related subject
-	<li>have tuition fee loans available from <a
-		href="https://www.gov.uk/student-finance">Student Finance England (SFE)</a>.</li>
-</ul>
-<p>
-	Graduate entry courses:
-</p>
-<ul>
-	<li>typically take one year of full-time study</li>
-	<li>provide a £7,000 grant to cover course fees</li>
-	<li>offer bursaries for graduates up to £5,000 for a first class degree</li>
-</ul>
-<p>
-	Graduate employment-based courses:
-</p>
-<ul>
-	<li>are one year part-time courses for graduates working in early years settings
-		who need further training to demonstrate the Teachers’ Standards (Early Years)</li>
-	<li> offer funding of £14,000 to cover up to £7,000 fees and £7,000 contribution
-		to employer costs</li>
-</ul>
-<p id="assessment-only">
-	Assessment Only is:
-</p>
-<ul>
-	<li>self-funded</li>
-	<li>maximum of 3 months duration</li>
-	<li>ideal for graduates with experience of working with children from birth age
-		to 5, who meet the Teachers’ Standards (Early Years) and have no need for further training
-	</li>
+<li>with a 2:2 or above in their undergraduate degree, a Masters or a PhD</li>
+<li>eligible to receive student support</li>
+<li>taking a qualifying postgraduate or undergraduate ITT course in England</li>
+<li>who comply with the terms and conditions of the bursary scheme</li>
+<li>not in possession of, or eligible for QTS</li>
+<li>not undertaking paid teaching work when in receipt of the bursary</li>
+<li>not simultaneously undertaking any other ITT course, training scheme or programme that leads to QTS</li>
 </ul>
 
-<h3 id="choose-a-subject">
-	Choose a subject
-</h3>
-<p>
-	<a
-		href="https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2">View
-	a list of secondary school teaching subjects</a>
-</p>
-<p>
-	When you apply for teacher training, you’ll be asked to give detailed evidence
-	for the knowledge and interest you bring to the subject(s) you’d like to teach.
-</p>
-<p>
-	Evidence can include:
-</p>
-<ul>
-	<li>the subject of your undergraduate degree</li>
-	<li>modules you studied as part of your degree</li>
-	<li>postgraduate degrees (for example, a Masters or PhD)</li>
-	<li>your A level subjects</li>
-	<li>expertise you’ve gained at work</li>
-</ul>
-<h3 id="subject-knowledge-enhancement-courses">Subject knowledge enhancement (SKE) courses</h3>
-		
-		<p>SKE courses are intended to help you enhance your knowledge so that you're able to teach a subject.</p>
-		<p>Your training provider will identify if you need to take one as part of their selection process, usually at interview.</p> 
-	      <p>They will ask you to complete an SKE course as a condition of taking up your offer of a teacher training place if they feel you need to enhance your subject knowledge.</p>
-		
-		<p>SKE courses are usually available if:</p>
-		<ul>
-			<li>your degree isn't in your chosen subject</li>
-			<li>you studied the subject at A level but not degree level </li> 
-			<li>you have an unrelated degree, but relevant professional experience in the subject</li>
+<h3>How you will be paid</h3>
+<p>You don’t need to apply for a bursary. If you’re enrolled on a non-salaried postgraduate course and meet the eligibility criteria, you will begin receiving payments from your chosen teacher training provider when you begin your course.</p><p> How you’re paid will depend on the amount of financial support you receive. If you’re awarded a bursary, you’ll receive this in 10 equal monthly instalments from October to July.</p> 
+<p>You are advised to confirm payment schedules with your training provider.</p>
+
+<h3>Undergraduate bursary</h3>
+<p>If you're a final year undergraduate student, you may be eligible for a training bursary of £9,000 if:</p>
+
+	<ul>
+		<li>you're studying a QTS course in secondary mathematics or physics</li>
+	  <li>you're studying an opt-in QTS course in secondary undergraduate computing, languages, mathematics or physics</li>
+		<li>your course started in the academic year 2021 to 2022</li>
 		</ul>
-		
-		<p>SKE courses can also be helpful if it’s been a while since you studied for your degree.</p>
-		
-<div role="note" aria-label="Information" class="application-notice info-notice">
-  <p>Please note that SKE courses for candidates starting Initial Teacher Training (ITT) in 2021/22 will not be available at the start of the recruitment cycle from 1 October 2020.</p>
-  <p>We will confirm the approach to SKEs following completion of the government's Spending Review.</p>
-  <p>ITT providers will be able to offer a teacher training place under the condition of completing an SKE course, but you won't be able to start one until funding and eligibility are confirmed after the Spending Review has been completed.</p>
-  <p>You should note that a conditional offer does not guarantee a funded SKE course will be available in your chosen subject.</p>		
-</div>
+
+<p>You will receive the bursary in the final year of your course.</p>
+<p>If you are eligible and on a 4-year undergraduate course that leads to QTS and a Master's degree, you will receive a £9,000 bursary in both the third and fourth years of your course.</p>
 
 
 
-<p>
-	You won't have to pay for your SKE course and you may be eligible for a bursary.
-</p>
-<p>
-	Your training provider will decide the course duration (between 8 and 28 weeks). This will depend on the knowledge you need. 
-</p>
-<p>
-	SKE courses can be completed before or, in some cases, alongside your teacher training. They are available to study full-time or part-time, classroom-based or online. 
-</p>
-<p>
-	SKE courses are usually available in:
-</p>
+<h3 id="troops">Troops to Teachers bursary</h3>
+
+<p>If you're a former service personnel you may be eligible for a tax-free bursary of £40,000 for an undergraduate degree leading to Qualified Teacher Status (QTS) in England.</p>
+<p>To be eligible for the bursary, you must:</p>
 <ul>
-	<li>biology</li>
-	<li>chemistry</li>
-	<li>computer studies</li>
-	<li>design and technology</li>
-	<li>English</li>
-	<li>geography</li>
-	<li>languages</li>
-	<li>maths</li>
-	<li>physics</li>
-	<li>primary maths</li>
-	<li>religious education</li>
-</ul>
-<p>The SKE directory sets out what courses are provided and will be updated once we have confirmed the approach to SKE courses for academic year 2020/21</p>
-		
-<p>
-	If you’re concerned about your subject knowledge, discuss it with your potential training providers.
-</p>
-		
-<h2 id="teaching-children-with-special-educational-needs-and-or-disabilities-SEND">
-	Teaching children with special educational needs and disabilities (SEND)
-</h2>
-<p>
-	Use <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
-	postgraduate teacher training</a> to search for training courses that involve working with SEND children.
-</p>
-<p>
-	Qualified SEND teachers are eligible for an extra payment, on top of their
-	annual salary, of between £2,209 and £4,359 a year.
-</p>
-<h4>Teaching SEND pupils</h4>
-<p>You don’t have to take a SEND specialist course. If you want to be a SEND teacher you can apply to teach in a special school if you have:</p>
-<ul>
-	<li>been teaching for a few years</li>
-	<li>experience of managing SEND pupils in your primary or secondary school</li>
+<li>train to teach secondary biology, physics, chemistry, computing, maths or modern foreign languages</li>
+<li>not already have a undergraduate degree</li>
+<li>have left full-time employment with the British Army, Royal Air Force or Royal Navy no more than 5 years before the start of the course</li>
+<li>be entitled to support under the <a href="https://www.gov.uk/student-finance/who-qualifies">Student Finance England</a> eligibility criteria</li>
 </ul>
 
-<h4>Teaching children with sensory impairments</h4>
-<p>If you want to teach pupils with hearing, vision or multi-sensory impairments, you’ll need a specific qualification. </p>
-<h4>Be a Special Educational Needs Coordinator (SENCo)</h4>
-<p>As a SENCo you’ll be responsible for assessing, planning and monitoring the progress of children with SEND. To apply for a job as a SENCo, you’ll need to:</p>
+<p>You can also apply for a tuition fee and maintenance loan for the duration of the course.</p>
+<p>For more information and to search for undergraduate teacher training courses visit <a href="https://www.ucas.com">UCAS</a>. When you’ve chosen some potential training providers for this programme, you should contact them for more details about eligibility and bursary payments.</p>
+
+<h2 id="scholarships">Scholarships</h2>
+<p>Scholarships are awarded in partnership with professional subject associations to the most gifted applicants, as a tax-free sum of money worth £26,000 by:</p>
 <ul>
-	<li>be a qualified teacher</li>
-	<li>complete the National Award in Special Educational Needs Coordination (NASENCO) when you take up the SENCO post</li>
+<li><a href="https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/">Royal Society of Chemistry</a> (chemistry)</li>
+<li><a href="https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/">BCS The Chartered Institute for IT</a> (computing)</li>
+<li><a href="https://ima.org.uk/support/mathematics-teacher-training-scholarship/">Mathematics Teacher Training Scholarship</a> (maths)</li>
+<li><a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref">Institute of Physics</a> (physics)</li>
 </ul>
 
-<h2 id="training-to-teach-if-you-have-a-disability">Training to teach if you have a disability</h2>
-<p>Teachers with disabilities make valuable contributions both to classrooms and the culture of schools where they work.
-</p>
-<h4>Your rights</h4>
-<p>
-	It is against the law for teacher training providers to discriminate against teacher training candidates with disabilities. Under the Equality Act 2010, providers must make adjustments to help you do a course or go to an interview, providing your requests are reasonable. Examples of support could be:
-</p>
-<ul>
-	<li>organising equipment like a hearing loop or an adapted keyboard</li>
-	<li>putting you in touch with support staff if you have a mental health
-		condition</li>
-	<li>making sure classrooms are wheelchair accessible</li>
-</ul>
-<p>
-	If the help you need is not covered by your provider making adjustments, you
-	might also be able to get support from <a
-		href="https://www.gov.uk/access-to-work">Access to Work</a>. This could include
-	a grant to help cover the costs of practical support in the workplace.
-</p>
-<h4>Telling your training provider about your disability when you apply</h4>
-  
-  <p>It’s up to you if you want to tell your training
-	provider about your disability. </p>
-  <p>information you give about your
-	disability is protected under the <a
-		href="https://www.gov.uk/data-protection/the-data-protection-act">Data
-  Protection Act 2018</a>.</p>
-  <h4>Completing a fitness questionnaire</h4>
-  <p>If you’re offered a place on a teacher
-	training course, you may have to complete a fitness questionnaire before
-	starting. Training providers should only ask relevant questions to make sure
-  you’re able to teach.</p>
-  <h4>Useful resources for disabled candidates</h4>
+<p>They are awarded according to each of the professional subject associations scholarship' eligibility criteria. If you are awarded one, you will not have to pay it back.</p>
+ 
+ 
+<h3>Apply for a scholarship</h3>
+<p>Apply for a scholarship through the awarding subject associations.</p> 
+<p>If you are not successful in applying, you may still be able to get a bursary.</p>
 
-<p><a
-	href="https://www.gov.uk/disabled-students-allowances-dsas">Get funding help if
-	you're a student with a learning difficulty, health problem or
-	disability</a>
-</p>
+<h3>How you will be paid</h3>
+<p>If you successfully apply for a scholarship and meet the subject awarding body criteria, you will be receive it in 10 equal monthly instalments from October to July.</p>
+<p>You are advised to confirm payment schedules with your training provider.</p>
 
-<p><a href="http://www.equalityhumanrights.com/en">The Equality and
-	Human Rights Commission (EHRC)</a> for information about discrimination on the
-  grounds of disablity.</p>
-<p><a href="http://www.abilitynet.org.uk/">AbilityNet</a> for advice on the use of
-	computers and communication technology for disabled
-  people.</p>
-<p><a
-		href="http://www.disabilityrightsuk.org/adjustments-disabled-students">Disability
-	Rights UK</a> for advice on adjustments for disabled students while
-	studying.
-</p>		
+
+
+
+		
+<h2 id="tuition-fee-maintenance-loans">Tuition fee and maintenance loans</h2>
 		
 		
-<h2 id="high-potential">High potential candidates, career changers and researchers</h2>
+		<p>
+	You can take out a loan with <a href="https://www.gov.uk/teacher-training-funding">student finance</a> to cover your tuition fees and help with your living costs (maintenance loan).
+</p>
+ <p>You can apply for:</p>
+	      <ul>
+		      <li>a tuition fee loan of up to £9,250 to cover the full cost of
+	your course fees</li>
+		      <li>a maintenance loan of up to £12,010 to help with your living costs</li>
+	      </ul>
 		
-		<h3 id="high-potential-itt">High Potential ITT</h3>
-	  <p><a href="https://www.teachfirst.org.uk/">Teach First</a> is a charity which runs the government-funded High Potential Initial Teacher Training programme (ITT). You’ll need to have a 2:1 degree or higher to apply for a place on the programme, currently delivered by Teach First. You’ll train over 2 years by learning on the job, paid as an unqualified teacher and you will not pay tuition fees.</p> 
-	  <p>You’ll be placed into a school straight away and gain QTS in your first year and complete your Newly Qualified Teacher placement in year 2. You’ll also receive leadership training, which includes a fully-funded Postgraduate Diploma in Education and Leadership (PGDE), worth double the credits of a PGCE.</p>
-
-
-<h3 id="career-changers">Career Changers</h3>
-<p>The Career Changers programme aims to attract high calibre graduates who have had a successful professional career with significant experience in their field into  teaching roles and schools where they are needed most.</p>
-		<p>It provides help and guidance with the transition from a previous career into teaching.</p> <p> Career changers can add value to teaching with:</p>
-<ul>
-	<li>previous employment experience</li>
-	<li>industry knowledge</li>
-	<li>wider perspectives into teaching practice and school policies</li>
-</ul>
+		
+		
+	<p>If you already have an undergraduate student loan, or have been awarded a bursary or scholarship, you can still apply for both a tuition fee and a maintenance loan.</p>
+		
 </p>
+	    <p>
+	Use the <a href="https://www.gov.uk/student-finance-calculator">student finance
+	calculator</a> to find out how much you can get.
+</p>  
 
-<p><a href="https://nowteach.org.uk/">Now Teach (NT)</a> and <a href="https://www.transitiontoteach.co.uk/">Transition to Teach (TT)</a> are bespoke teacher recruitment and retention programmes developed exclusively to support career changers, providing transitional support and additional mentoring so that successful career changers can get the most out of their transition to teaching.</p>
 
-
-
-<h3 id="researchers-in-schools">Researchers in Schools (candidates with a doctorate)
-</h3>
-<p>Researchers in Schools, which includes the Maths and Physics Chairs programme, is a tailored, teacher training and professional development course for high-calibre candidates.</p>
-<p>The programme is designed to run over 3 years, and offers both a salaried and bursary route into teacher training depending on your prior experiences and circumstances. </p>
+	      <h3>If you already have a student loan</h3>
+<p>You are only required to make repayments on your loan when you are earning over:</p
+		
+	<ul>
+		<li>£26,575, if you took it out after 1 September 2012</li>
+		<li>£19,390, if you took it out before 1 September 2012</li>
+	</ul>
+		
 <p>
-	To <a href="https://researchersinschools.org/">apply to this teacher training
-	programme</a>, you'll need (or be about to finish) a doctorate in one of the following subjects:
+	Your repayments will not increase if you take out another loan for teacher training.
 </p>
-<ul>
-	<li>physics</li>
-	<li>mathematics</li>
-	<li>chemistry</li>
-	<li>biology</li>
-	<li>engineering</li>
-	<li>computing</li>
-	<li>English</li>
-	<li>history</li>
-	<li>classics (Latin or Greek)</li>
-	<li>modern foreign languages (French, German or Spanish)</li>
-</ul>
 
 <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
   <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
   </svg>Back to top
 </a>
-
-
-
-	
-<h2 id="get-a-job-in-teaching">
-	Get a job in teaching
+	    
+<h2 id="parents-and-carers">Parents and carers - extra financial support
 </h2>
 <p>
-	You can find teaching jobs by searching the Department for Education’s <a
-		href="https://teaching-vacancies.service.gov.uk/">Teaching Vacancies</a>
-	service.
+	You may be able to apply for:</p>
+	    <ul>
+		    <li><a
+		href="https://www.gov.uk/parents-learning-allowance">Parents’ Learning
+	Allowance</a></li>
+		    <li><a href="https://www.gov.uk/childcare-grant">Childcare
+	Grant</a></li>
+		    <li><a
+		href="https://www.gov.uk/adult-dependants-grant">Adult Dependants’
+	Grant</a></li>
+	    
+	    </ul>
+	    
+	    <p>You do not need to pay back these kinds of financial support.</p>
 </p>
-<p>
-	The service is used by 70% of state schools in England. Search by location,
-	subject, job title and salary and set up job alerts.
-</p>
+	  
 <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
   <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
   </svg>Back to top
 </a>
+	 
+	  <h2 id="disabled-students">Disabled students - extra financial support</h2>
+<p>If you have additional needs due to a mental health condition, long-term illness or disability you can apply for <a href="https://www.gov.uk/disabled-students-allowances-dsas/how-to-claim" target="_blank">Disabled Students’ Allowances (DSAs)</a>.</p>
 
+		
 
-<h2 id="contact-and-support">
-	Contact and support
-</h2>
-<h3>
-	Chat online
-</h3>
-<p>
-	Contact Get into
-	Teaching’s live <a href="/#talk-to-us">online chat service</a> between 8.30am and 5pm, Monday to Friday.
-</p>
-	<h3>Speak on the phone</h3>
-
-<p>
-	You can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a> between 8.30am and 5pm,
-	Monday to Friday.
-</p>
-
-  <h3>Find an event near you</h3>
+  <h2 id="find-train-to-teach-event">Find a Train To Teach event near you</h2>
   <p>
   <a href="events"  target="_blank" rel="noopener noreferrer">Get Into Teaching’s nationwide
 	  events</a> are informal opportunities for you to get free expert advice about your
 	next steps into teaching.
 </p>
-<a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+
+	  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
   <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
   </svg>Back to top
 </a>
-<h2 id="further-support-and-information">Further support and information</h2>
+	  
+<h2 id="help-and-support">
+	Contact and support
+</h2>
+
+<p>
+	Contact Get into
+	Teaching’s live <a href="/#talk-to-us">online chat service</a> between 8.30am and 5pm, Monday to Friday.
+</p>
+	
+<p>
+	Call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a> between 8.30am and 5pm,
+	Monday to Friday.
+</p>
 
 <p>Send an email to:
-<a href="mailto:getintoteaching.helpdesk@education.gov.uk" class="govuk-link">getintoteaching.helpdesk@education.gov.uk</a>
- or call Freephone 0800 389 2501.</p>
+<a href="mailto:getintoteaching.helpdesk@education.gov.uk" class="govuk-link">getintoteaching.helpdesk@education.gov.uk</a>.</p>
 
 </div>
 </div>
+	  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+  </svg>Back to top
+</a>
 
 
   <div class="responsive-bottom-margin">
@@ -938,7 +605,7 @@
   <ul class="gem-c-related-navigation__link-list" data-module="track-click">
 
 
-   <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" href="https://beta-getintoteaching.education.gov.uk">Get Into Teaching</a></li>
+   <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" href="/">Get Into Teaching</a></li>
 
   </ul>
 </nav>

--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -30,7 +30,7 @@ navigation: 10
  <p>For a scholarship, each professional scholarship body sets its own criteria.</p>
  <p>You could get a bursary of up to £24,000 or apply for a scholarship of up to £26,000.</p>
  
-<p><a href="/finance-guidance#bursaries-and-scholarships" target="_blank" rel="noopener noreferrer">Find out more about bursaries and scholarships<span class="govuk-visually-hidden">(Link opens in new
+<p><a href="/financial-support-for-teacher-training#bursaries-and-scholarships" target="_blank" rel="noopener noreferrer">Find out more about bursaries and scholarships<span class="govuk-visually-hidden">(Link opens in new
 window)</span><i class="icon icon-external"></i></a>.</p>
 
   <h2 id="get-student-finance">Tuition fee and maintenance loans</h2>
@@ -40,7 +40,7 @@ window)</span><i class="icon icon-external"></i></a>.</p>
   
  <p>You will only have to make repayments when you're earning. Your repayments will not increase if you already have a student loan and take a loan out for teacher training.</p>
 
-  <p><a href="/finance-guidance#tuition-fee-maintenance-loans" target="_blank" rel="noopener noreferrer">Find out more about tuition fee and maintenance loans<span class="govuk-visually-hidden">(Link opens in new
+  <p><a href="/financial-support-for-teacher-training#tuition-fee-maintenance-loans" target="_blank" rel="noopener noreferrer">Find out more about tuition fee and maintenance loans<span class="govuk-visually-hidden">(Link opens in new
 window)</span><i class="icon icon-external"></i></a>.</p> 
 
   <p>Use the <a href="https://www.gov.uk/student-finance-calculator" target="_blank" rel="noopener noreferrer">student finance calculator on GOV.UK<span class="govuk-visually-hidden">(Link opens in new
@@ -59,8 +59,8 @@ window)</span><i class="icon icon-external"></i></a> to find out how much you ca
     <li><span>Adult Dependants’ Grant</span></li>
   </ul>
   
-  <p>Find out more about extra financial support for <a href="/finance-guidance#parents-and-carers" target="_blank" rel="noopener noreferrer">parents and carers<span class="govuk-visually-hidden">(Link opens in new
-window)</span><i class="icon icon-external"></i></a> and <a href="/finance-guidance#disabled-students" target="_blank" rel="noopener noreferrer">people with disabilities<span class="govuk-visually-hidden">(Link opens in new
+  <p>Find out more about extra financial support for <a href="/financial-support-for-teacher-training#parents-and-carers" target="_blank" rel="noopener noreferrer">parents and carers<span class="govuk-visually-hidden">(Link opens in new
+window)</span><i class="icon icon-external"></i></a> and <a href="/financial-support-for-teacher-training#disabled-students" target="_blank" rel="noopener noreferrer">people with disabilities<span class="govuk-visually-hidden">(Link opens in new
 window)</span><i class="icon icon-external"></i></a>.</p> 
 
 

--- a/content/steps-to-become-a-teacher.md
+++ b/content/steps-to-become-a-teacher.md
@@ -40,7 +40,7 @@ navigation: 20
    <p>
         If you do not have the required GCSEs, you’ll need to show that you have an equivalent level of education.
       </p>
-      <p><a href="/ways-to-train-guidance#subject-knowledge-enhancement-courses" target="_blank" rel="noopener noreferrer">If your degree is not in the subject you want to teach<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></p>
+      <p><a href="/train-to-become-a-teacher#subject-knowledge-enhancement-courses" target="_blank" rel="noopener noreferrer">If your degree is not in the subject you want to teach<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></p>
       
    <p>
     Here's what you need to do if you:
@@ -106,7 +106,7 @@ navigation: 20
 
   
   
-  <a href="/ways-to-train-guidance" target="_blank" rel="noopener noreferrer">Find out more about different ways to train<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>
+  <a href="/train-to-become-a-teacher" target="_blank" rel="noopener noreferrer">Find out more about different ways to train<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>
 
 
   <h3>Teaching children with special educational needs and disabilities (SEND)</h3>
@@ -116,7 +116,7 @@ navigation: 20
       <p>
         You could also specialise in supporting children with SEND.
       </p>
-      <a href="/ways-to-train-guidance#teaching-children-with-special-educational-needs-and-or-disabilities-SEND" target="_blank" rel="noopener noreferrer">Find out how to specialise in SEND<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>
+      <a href="/train-to-become-a-teacher#teaching-children-with-special-educational-needs-and-or-disabilities-SEND" target="_blank" rel="noopener noreferrer">Find out how to specialise in SEND<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>
       
       
    </div>

--- a/content/steps-to-become-a-teacher/if-you-need-to-get-the-right-qualifications.md
+++ b/content/steps-to-become-a-teacher/if-you-need-to-get-the-right-qualifications.md
@@ -35,7 +35,7 @@ Alternatively, if you are currently studying for, or have already been awarded y
 
 <h2 id="if-your-degree-is-not-in-the-subject-you-want-to-teach">Increase your knowledge of the subject you want to teach</h2>
 
-<p>If you need to top up your knowledge of the subject you want to teach, you could take a <a href="/guidance#subject-knowledge-enhancement-courses"  target="_blank" rel="noopener noreferrer">subject knowledge enhancement course (SKE)<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>.</p> 
+<p>If you need to top up your knowledge of the subject you want to teach, you could take a <a href="/train-to-become-a-teacher#subject-knowledge-enhancement-courses"  target="_blank" rel="noopener noreferrer">subject knowledge enhancement course (SKE)<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>.</p> 
   
  <p>A SKE may be right for you if:</p>
 
@@ -46,38 +46,38 @@ Alternatively, if you are currently studying for, or have already been awarded y
   <li><span>it’s been some time since you used your degree knowledge</span></li>
   </ul>
 
-<p>If you want more information, read the <a href="/guidance#subject-knowledge-enhancement-courses"  target="_blank" rel="noopener noreferrer">UK government guidance on SKE courses<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>.</p>
+<p>If you want more information, read the <a href="/train-to-become-a-teacher#subject-knowledge-enhancement-courses"  target="_blank" rel="noopener noreferrer">UK government guidance on SKE courses<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>.</p>
 
 <h2 id="specialist-ways-to-get-into-teaching">Specialist ways to get into teaching</h2>
 
 <h3>School Direct salaried places</h3>
 
-<p>You’ll earn a <a href="/guidance#salaried"  target="_blank" rel="noopener noreferrer">salary while you train<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> and you will not pay tuition fees. These places are usually given to graduates with at least 3 years’ work experience.</p>
+<p>You’ll earn a <a href="/train-to-become-a-teacher#salaried"  target="_blank" rel="noopener noreferrer">salary while you train<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> and you will not pay tuition fees. These places are usually given to graduates with at least 3 years’ work experience.</p>
 
 <h3>Postgraduate teaching apprenticeship</h3>
 
-<p><a href="/guidance#salaried"  target="_blank" rel="noopener noreferrer">Postgraduate teaching apprenticeships<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> are similar to school direct salaried places. You’ll be employed by a school to learn on the job over 4 terms. You’ll then take an assessment. This is a salaried training place so you will not pay tuition fees.</p>
+<p><a href="/train-to-become-a-teacher#salaried"  target="_blank" rel="noopener noreferrer">Postgraduate teaching apprenticeships<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> are similar to school direct salaried places. You’ll be employed by a school to learn on the job over 4 terms. You’ll then take an assessment. This is a salaried training place so you will not pay tuition fees.</p>
 
 <h3>Career changers</h3>
 
-<p>If you want a <a href="/guidance#career-changers"  target="_blank" rel="noopener noreferrer">career change and fancy becoming a teacher<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>, you’ll get the chance to use your life and work experience coupled with your passion for your subject to inspire young people.  There's plenty of support to get into teaching and make the career change. </p>
+<p>If you want a <a href="/train-to-become-a-teacher#career-changers"  target="_blank" rel="noopener noreferrer">career change and fancy becoming a teacher<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>, you’ll get the chance to use your life and work experience coupled with your passion for your subject to inspire young people.  There's plenty of support to get into teaching and make the career change. </p>
 
 <h3>High Potential ITT</h3>
 
-<p>You’ll need to have a 2:1 degree or higher to apply for a place on the programme, currently delivered by <a href="/guidance#high-potential-itt"  target="_blank" rel="noopener noreferrer">Teach First<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. You’ll train over 2 years by learning on the job, paid as an unqualified teacher and you will not pay tuition fees. You’ll be placed into a school straight away and gain QTS in your first year and complete your Newly Qualified Teacher placement in year 2.</p>
+<p>You’ll need to have a 2:1 degree or higher to apply for a place on the programme, currently delivered by <a href="/train-to-become-a-teacher#high-potential-itt"  target="_blank" rel="noopener noreferrer">Teach First<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. You’ll train over 2 years by learning on the job, paid as an unqualified teacher and you will not pay tuition fees. You’ll be placed into a school straight away and gain QTS in your first year and complete your Newly Qualified Teacher placement in year 2.</p>
 <p>You’ll also receive leadership training, which includes a fully-funded Postgraduate Diploma in Education and Leadership (PGDE), worth double the credits of a PGCE.</p>
 
 <h3>Researchers in schools</h3>
 
-<p>You’ll need (or be about to finish) a doctorate in the <a href="/guidance#researchers-in-schools"  target="_blank" rel="noopener noreferrer">subject you want to teach<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. You’ll then train over 3 years with a bursary. If you have a lot of relevant work experience you could train and earn a salary.</p>
+<p>You’ll need (or be about to finish) a doctorate in the <a href="/train-to-become-a-teacher#researchers-in-schools"  target="_blank" rel="noopener noreferrer">subject you want to teach<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. You’ll then train over 3 years with a bursary. If you have a lot of relevant work experience you could train and earn a salary.</p>
 
 <h3>Assessment only (AO)</h3>
 
-<p>If you’re a teaching assistant or unqualified teacher with two years’ experience you can be <a href="/guidance#assessment-only-candidates-already-working-in-school"  target="_blank" rel="noopener noreferrer">assessed over 12 weeks to get QTS<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. This way of getting QTS will not give you a PGCE.</p>
+<p>If you’re a teaching assistant or unqualified teacher with two years’ experience you can be <a href="/train-to-become-a-teacher#assessment-only-candidates-already-working-in-school"  target="_blank" rel="noopener noreferrer">assessed over 12 weeks to get QTS<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a>. This way of getting QTS will not give you a PGCE.</p>
 
 <h3>Postgraduate Early Years Initial Teacher Training (EYITT)</h3>
 
-<p>A number of postgraduate Early Years Initial Teacher Training (EYITT) courses are available at university or via a school-led route – all lead to <a href="/guidance#teaching-under-fives"  target="_blank" rel="noopener noreferrer">Early Years Teacher Status (EYTS)<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> on successful completion. EYTS is different to QTS in that you specialise in working with children up to five years old only.</p>
+<p>A number of postgraduate Early Years Initial Teacher Training (EYITT) courses are available at university or via a school-led route – all lead to <a href="/train-to-become-a-teacher#teaching-under-fives"  target="_blank" rel="noopener noreferrer">Early Years Teacher Status (EYTS)<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a> on successful completion. EYTS is different to QTS in that you specialise in working with children up to five years old only.</p>
 
 
 <p><a href="https://www.gov.uk/find-postgraduate-teacher-training-courses"  target="_blank" rel="noopener noreferrer">Find a school-led teacher training course<span class="govuk-visually-hidden">(Link opens in new window)</span><i class="icon icon-external"></i></a></p>

--- a/content/train-to-become-a-teacher.html.erb
+++ b/content/train-to-become-a-teacher.html.erb
@@ -2,13 +2,13 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <style type="text/css" id="alertifyCSS">.alertify-logs>*{padding:12px 24px;color:#fff;box-shadow:0 2px 5px 0 rgba(0,0,0,.2);border-radius:1px}.alertify-logs>*,.alertify-logs>.default{background:rgba(0,0,0,.8)}.alertify-logs>.error{background:rgba(244,67,54,.8)}.alertify-logs>.success{background:rgba(76,175,80,.9)}.alertify{position:fixed;background-color:rgba(0,0,0,.3);left:0;right:0;top:0;bottom:0;width:100%;height:100%;z-index:2}.alertify.hide{opacity:0;pointer-events:none}.alertify,.alertify.show{box-sizing:border-box;transition:all .33s cubic-bezier(.25,.8,.25,1)}.alertify,.alertify *{box-sizing:border-box}.alertify .dialog{padding:12px}.alertify .alert,.alertify .dialog{width:100%;margin:0 auto;position:relative;top:50%;-webkit-transform:translateY(-50%);transform:translateY(-50%)}.alertify .alert>*,.alertify .dialog>*{width:400px;max-width:95%;margin:0 auto;text-align:center;padding:12px;background:#fff;box-shadow:0 2px 4px -1px rgba(0,0,0,.14),0 4px 5px 0 rgba(0,0,0,.098),0 1px 10px 0 rgba(0,0,0,.084)}.alertify .alert .msg,.alertify .dialog .msg{padding:12px;margin-bottom:12px;margin:0;text-align:left}.alertify .alert input:not(.form-control),.alertify .dialog input:not(.form-control){margin-bottom:15px;width:100%;font-size:100%;padding:12px}.alertify .alert input:not(.form-control):focus,.alertify .dialog input:not(.form-control):focus{outline-offset:-2px}.alertify .alert nav,.alertify .dialog nav{text-align:right}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button),.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button){background:transparent;box-sizing:border-box;color:rgba(0,0,0,.87);position:relative;outline:0;border:0;display:inline-block;-webkit-align-items:center;-ms-flex-align:center;-ms-grid-row-align:center;align-items:center;padding:0 6px;margin:6px 8px;line-height:36px;min-height:36px;white-space:nowrap;min-width:88px;text-align:center;text-transform:uppercase;font-size:14px;text-decoration:none;cursor:pointer;border:1px solid transparent;border-radius:2px}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):active,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):hover{background-color:rgba(0,0,0,.05)}.alertify .alert nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus,.alertify .dialog nav button:not(.btn):not(.pure-button):not(.md-button):not(.mdl-button):focus{border:1px solid rgba(0,0,0,.1)}.alertify .alert nav button.btn,.alertify .dialog nav button.btn{margin:6px 4px}.alertify-logs{position:fixed;z-index:1}.alertify-logs.bottom,.alertify-logs:not(.top){bottom:16px}.alertify-logs.left,.alertify-logs:not(.right){left:16px}.alertify-logs.left>*,.alertify-logs:not(.right)>*{float:left;-webkit-transform:translateZ(0);transform:translateZ(0);height:auto}.alertify-logs.left>.show,.alertify-logs:not(.right)>.show{left:0}.alertify-logs.left>*,.alertify-logs.left>.hide,.alertify-logs:not(.right)>*,.alertify-logs:not(.right)>.hide{left:-110%}.alertify-logs.right{right:16px}.alertify-logs.right>*{float:right;-webkit-transform:translateZ(0);transform:translateZ(0)}.alertify-logs.right>.show{right:0;opacity:1}.alertify-logs.right>*,.alertify-logs.right>.hide{right:-110%;opacity:0}.alertify-logs.top{top:0}.alertify-logs>*{box-sizing:border-box;transition:all .4s cubic-bezier(.25,.8,.25,1);position:relative;clear:both;-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-perspective:1000;perspective:1000;max-height:0;margin:0;padding:0;overflow:hidden;opacity:0;pointer-events:none}.alertify-logs>.show{margin-top:12px;opacity:1;max-height:1000px;padding:12px;pointer-events:auto}</style>
-  <meta property="og:description" content="Become a teacher in England">
-  <meta property="og:title" content="Become a teacher in England">
-  <meta property="og:url" content="https://beta-getintoteaching.education.gov.uk/guidance">
+  <meta property="og:description" content="Train to become a teacher">
+  <meta property="og:title" content="Train to become a teacher">
+  <meta property="og:url" content="https://beta-getintoteaching.education.gov.uk/ways-to-train-guidance">
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="GOV.UK">
   <meta name="twitter:card" content="summary">
-  <meta name="description" content="Become a teacher in England">
+  <meta name="description" content="Train to become a teacher">
   <meta name="govuk:taxon-slugs" content="become-a-teacher-in-england">
   <meta name="govuk:taxon-slug" content="become-a-teacher-in-england">
   <meta name="govuk:taxon-ids" content="2682bef9-0963-43e3-8610-30b31ec1c4d0,56b78356-c7bf-4460-8775-d04b590ec7ca">
@@ -43,7 +43,7 @@
     <%- end -%>
   </script>
   <title lang="en">
-     Financial support for teacher training
+      Train to become a teacher
   </title>
   <!--[if gt IE 8]><!-->
   <link rel="stylesheet" media="screen" href="https://www.gov.uk/assets/static/govuk-template-ec01c15a0e8793975bcaf519e4eb3ec0d68a99610c6b262fa7a1b3c7f76f6176.css">
@@ -230,7 +230,7 @@
     <span class="govuk-caption-xl gem-c-title__context">
       Guidance
     </span>
-  <h1 class="gem-c-title__text gem-c-title__text--long" id="top">Financial support for teacher training</h1>
+  <h1 class="gem-c-title__text gem-c-title__text--long" id="top">Train to become a teacher</h1>
 </div>
   </div>
 
@@ -283,30 +283,45 @@
         <nav class="gem-c-contents-list  gem-c-contents-list--no-underline " role="navigation" data-module="track-click" aria-label="Contents">
           <h2 class="gem-c-contents-list__title">Contents</h2>
           <ol class="gem-c-contents-list__list">
-		  <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
               <a class="gem-c-contents-list__link govuk-link" href="#introduction">Introduction</a>
             </li>
             <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#bursaries">Bursaries</a>
-            </li>
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#scholarships">Scholarships</a>
-            </li>
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link" href="#tuition-fee-maintenance-loans">Tuition fee and maintenance loans</a>
-            </li>
-            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link " href="#parents-and-carers">Parents and carers - extra financial support</a>
-            </li>
-	    <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link " href="#disabled-students">Disabled students - extra financial support</a>
-            </li>
-		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
-              <a class="gem-c-contents-list__link govuk-link " href="#find-train-to-teach-event">Find a Train To Teach event near you</a>
-		  </li>  
+              <a class="gem-c-contents-list__link govuk-link" href="#what-youll-need-to-work-as-a-teacher">What you’ll need to work as a teacher</a>
+		    </li>
 		  <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#gaining-qts">Gaining Qualified Teacher Status</a>
+            </li>
+		   
+		  
+		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#training-providers">Types of teacher training provider</a>
+            </li>
+		   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#salaried">Salaried teacher training courses</a>
+            </li>
+		
+		<li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#things-to-consider">Things to consider before you apply</a>
+            </li>
+		
+		   
+		     <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#training-to-teach-if-you-have-a-disability">Training to teach if you have a disability</a>
+		</li>
+		   <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#high-potential">High potential candidates, career changers and researchers</a>
+            </li>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link" href="#teaching-children-with-special-educational-needs-and-or-disabilities-SEND">Teaching children with special educational needs and disabilities (SEND)</a>
+            </li>
+           
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
+              <a class="gem-c-contents-list__link govuk-link " href="#get-a-job-in-teaching">Get a job in teaching</a>
+            </li>
+            <li class="gem-c-contents-list__list-item gem-c-contents-list__list-item--dashed">
               <a class="gem-c-contents-list__link govuk-link " href="#contact-and-support">Contact and support</a>
-		  </li>
+            </li>
           </ol>
         </nav>
       </div>
@@ -314,207 +329,544 @@
       
       <div class="gem-c-govspeak govuk-govspeak direction-ltr" data-module="govspeak">
         <div class="govspeak">
+          <h2 id="introduction">Introduction</h2>
           
 
 
 
-
-
-<h2 id="introduction">Introduction</h2>
-<p>
-	The level of financial support you get will depend on the subject you choose and the way you train to become a teacher.
-</p>
-<p>
-	There are several types of funding that may all be available to you, depending on your eligibility:
-</p>
-        <ul>
-	<li>a bursary or scholarship</li>
-	<li>tuition fee and maintenance loans</li>
-	<li>extra financial support if you're a parent, a carer, or you have a disability</li>	
-        </ul>
-
-<p>For advice about bursaries or scholarships, you can <a href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">chat online</a> or call Freephone 0800 389 2501 between 8.30am and 5pm, Monday to Friday.</p>
-
-<p>
-	Please note that alternative funding is in place to train as an Early Years teacher, which leads to achieving Early Years Teacher Status (EYTS).
-</p>
-		
-<h2 id="bursaries">Bursaries</h2>
-<p>A bursary is a tax-free sum of money awarded to high quality graduates who meet eligibility criteria and train to teach in certain subjects. You may be eligible for a bursary or a scholarship but you cannot receive both. If you receive one, you will not have to pay it back.</p> 
-
-<p>They are only available in the following subjects:</p>
-<ul>
-<li>chemistry, computing, maths, physics - £24,000</li>
-<li>classics, languages - £10,000</li>
-<li>biology - £7,000</li>
-</ul>
-
-<h3>Eligibility</h3>
-
-<p>Bursaries are awarded to candidates:</p>
-<ul>
-<li>with a 2:2 or above in their undergraduate degree, a Masters or a PhD</li>
-<li>eligible to receive student support</li>
-<li>taking a qualifying postgraduate or undergraduate ITT course in England</li>
-<li>who comply with the terms and conditions of the bursary scheme</li>
-<li>not in possession of, or eligible for QTS</li>
-<li>not undertaking paid teaching work when in receipt of the bursary</li>
-<li>not simultaneously undertaking any other ITT course, training scheme or programme that leads to QTS</li>
-</ul>
-
-<h3>How you will be paid</h3>
-<p>You don’t need to apply for a bursary. If you’re enrolled on a non-salaried postgraduate course and meet the eligibility criteria, you will begin receiving payments from your chosen teacher training provider when you begin your course.</p><p> How you’re paid will depend on the amount of financial support you receive. If you’re awarded a bursary, you’ll receive this in 10 equal monthly instalments from October to July.</p> 
-<p>You are advised to confirm payment schedules with your training provider.</p>
-
-
-
-<h3 id="troops">Troops to Teachers bursary</h3>
-
-<p>If you're a former service personnel you may be eligible for a tax-free bursary of £40,000 for an undergraduate degree leading to Qualified Teacher Status (QTS) in England.</p>
-<p>To be eligible for the bursary, you must:</p>
-<ul>
-<li>train to teach secondary biology, physics, chemistry, computing, maths or modern foreign languages</li>
-<li>not already have a undergraduate degree</li>
-<li>have left full-time employment with the British Army, Royal Air Force or Royal Navy no more than 5 years before the start of the course</li>
-<li>be entitled to support under the <a href="https://www.gov.uk/student-finance/who-qualifies">Student Finance England</a> eligibility criteria</li>
-</ul>
-
-<p>You can also apply for a tuition fee and maintenance loan for the duration of the course.</p>
-<p>For more information and to search for undergraduate teacher training courses visit <a href="https://www.ucas.com">UCAS</a>. When you’ve chosen some potential training providers for this programme, you should contact them for more details about eligibility and bursary payments.</p>
-
-<h2 id="scholarships">Scholarships</h2>
-<p>Scholarships are awarded in partnership with professional subject associations to the most gifted applicants, as a tax-free sum of money worth up to £26,000 by:</p>
-<ul>
-<li><a href="https://www.rsc.org/awards-funding/funding/teacher-training-scholarships/">Royal Society of Chemistry</a> (chemistry)</li>
-<li><a href="https://www.bcs.org/get-qualified/certification-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/">BCS The Chartered Institute for IT</a> (computing)</li>
-<li><a href="https://ima.org.uk/support/mathematics-teacher-training-scholarship/">Mathematics Teacher Training Scholarship</a> (maths)</li>
-<li><a href="https://www.iop.org/about/support-grants/iop-teacher-training-scholarships#gref">Institute of Physics</a> (physics)</li>
-</ul>
-
-<p>They are awarded according to each of the professional subject associations scholarship' eligibility criteria. If you are awarded one, you will not have to pay it back.</p>
- 
- 
-<h3>Apply for a scholarship</h3>
-<p>Apply for a scholarship through the awarding subject associations.</p> 
-<p>If you are not successful in applying, you may still be able to get a bursary.</p>
-
-<h3>How you will be paid</h3>
-<p>If you successfully apply for a scholarship and meet the subject awarding body criteria, you will be receive it in 10 equal monthly instalments from October to July.</p>
-<p>You are advised to confirm payment schedules with your training provider.</p>
-
-
-
-
-		
-<h2 id="tuition-fee-maintenance-loans">Tuition fee and maintenance loans</h2>
-		
-		
-		<p>
-	You can take out a loan with <a href="https://www.gov.uk/teacher-training-funding">student finance</a> to cover your tuition fees and help with your living costs (maintenance loan).
-</p>
- <p>You can apply for:</p>
-	      <ul>
-		      <li>a tuition fee loan of up to £9,250 to cover the full cost of
-	your course fees</li>
-		      <li>a maintenance loan of up to £12,010 to help with your living costs</li>
-	      </ul>
-		
-		
-		
-	<p>If you already have an undergraduate student loan, or have been awarded a bursary or scholarship, you can still apply for both a tuition fee and a maintenance loan.</p>
-		
-</p>
-	    <p>
-	Use the <a href="https://www.gov.uk/student-finance-calculator">student finance
-	calculator</a> to find out how much you can get.
-</p>  
-
-
-	      <h3>If you already have a student loan</h3>
-<p>You are only required to make repayments on your loan when you are earning over:</p
-		
-	<ul>
-		<li>£26,575, if you took it out after 1 September 2012</li>
-		<li>£19,390, if you took it out before 1 September 2012</li>
-	</ul>
-		
-<p>
-	Your repayments will not increase if you take out another loan for teacher training.
-</p>
-
-<a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
-  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-  </svg>Back to top
-</a>
-	    
-<h2 id="parents-and-carers">Parents and carers - extra financial support
+<h2 id="what-youll-need-to-work-as-a-teacher">
+	What you’ll need to work as a teacher
 </h2>
 <p>
-	You may be able to apply for:</p>
-	    <ul>
-		    <li><a
-		href="https://www.gov.uk/parents-learning-allowance">Parents’ Learning
-	Allowance</a></li>
-		    <li><a href="https://www.gov.uk/childcare-grant">Childcare
-	Grant</a></li>
-		    <li><a
-		href="https://www.gov.uk/adult-dependants-grant">Adult Dependants’
-	Grant</a></li>
-	    
-	    </ul>
-	    
-	    <p>You do not need to pay back these kinds of financial support.</p>
+	To work as a qualified teacher in state schools in England, you’ll need
+	Qualified Teacher Status (QTS).
 </p>
-	  
+		
+<p>
+	QTS allows you to teach as a qualified teacher in state-maintained schools and non-maintained special schools in England. It may also allow you to teach in other parts of the UK. 
+</p>
+<p>
+	There is information available about teaching in <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a>, <a href="https://teachinscotland.scot/">Scotland</a> and <a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a>.
+</p>
+
+<p>
+	Undergraduate teacher training leading to QTS can take up to 4 years.
+</p>
+<p>
+	Graduate teacher training leading to QTS typically takes one year of full-time study. Some providers offer part-time study, which typically take 2 years.
+</p>
+<p>
+	Once you’ve gained your QTS, you can apply for jobs as a
+	newly-qualified teacher (NQT).
+</p>
+<p>
+	NQTs do a further 'induction programme' in school as a paid and qualified teacher, which allows them to build on their initial teacher training.
+</p>
+		
+	<h3 id="assessment-only-candidates-already-working-in-school">
+	Assessment only (candidates already working in school)
+	</h3>
+<p>
+	If you’re an unqualified teacher with 2 years’ experience, you can be assessed over a maximum of 12 weeks to gain Qualified Teacher Status (QTS).
+</p>
+<p>
+	Although you may not need to take a formal teacher training course, you must
+	meet the eligibility requirements for teacher training - which includes a degree, and GCSEs (or a standard equivalent) in English, maths, and science for primary school teaching.
+</p>
+		
+<h2 id="gaining-qts">
+	Gaining Qualified Teacher Status
+</h2>
+		<h3>PGCE with QTS</h3>
+<p>
+	A PGCE (postgraduate certificate in education) with QTS gives you an academic qualification as well as QTS.  Many PGCE courses include credits that count towards a Master’s degree.
+</p>
+<P>
+	A PGCE may allow you to teach in some other countries. If you’re planning to teach overseas, you should always check what’s needed in the country you’d like to teach in.
+</P>
+		<h3>PGDE with QTS</h3>
+<p>
+	Some providers offer a PGDE (postgraduate diploma in education) with QTS. In some cases these courses offer more credits towards
+	a Master’s degree than PGCE courses.
+</p>
+
+<H4>
+	Further education (PGCE or PGDE without QTS)
+</H4>
+<p>
+	To teach further education you do not need QTS. Instead you can study for a PGCE
+	or PGDE without QTS. These courses are also eligible for candidates without a
+	degree.
+</p>
+		
+		
+		
+<h3 id="find-postgraduate-teacher-training">
+	Find postgraduate teacher training
+</h3>
+	<p>
+	All primary and secondary teacher training courses on <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training courses</a> lead to QTS.
+        </p>	
+		
+<p>
+	Use <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
+	postgraduate teacher training courses</a> to search and compare
+	government-approved teacher training providers in your area.
+</p>
+
+<p>
+	You can also search for ‘further education’ courses leading to a post-compulsory
+	education and training qualification (PCET). You do not need a degree to apply
+	for courses leading to a PCET.
+</p>
+		
+<h2 id="salaried">
+	Salaried teacher training courses
+</h2>
+
+<p>
+	Under some circumstances, you can train as a teacher ‘on the job’. On these courses, you will:
+</p>
+<ul>
+	<li>earn a salary
+	<li>pay no student fees for training towards QTS</li>
+</ul>
+
+<p>
+	There are 3 options available:
+</p>
+<ul>
+	<li>School Direct (salaried)</li>
+	<li>Postgraduate teaching apprenticeships</li>
+	<li>High Potential Initial Teacher Training Programme</li>
+</ul>
+	<p>On these courses you’ll be paid and taxed as an unqualified teacher. The salary awarded will differ between schools – you should check the salary with the school before you apply.
+</p>
+<p>
+	These courses do not offer bursaries, scholarships or student
+	finance. There are usually no course fees to pay.
+</p>
+<p>
+	Both School Direct (salaried) and postgraduate apprenticeship courses will lead to QTS.  If you choose to do a postgraduate teaching apprenticeship, you’ll also have to sit an ‘end point assessment’ (EPA). 
+</p>
+<p>
+	Select ‘only salaried courses’ in <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find postgraduate teacher training</a> to find local courses.
+</p>
+		
+<h2 id="training-providers">
+	Types of teacher training provider
+</h2>
+<p>
+	You can do your teacher training on a course run by a university, an individual
+	school, or a partnership of schools (sometimes called a SCITT, standing for
+	‘school-centred initial teacher training’).
+</p>
+<p>
+	Although the type of institution (school or university) running the course will
+	differ, the content of the course will meet national guidelines on teacher
+	training.
+</p>
+<p>
+	The primary and secondary teacher training courses listed on <a
+		href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
+	postgraduate teacher training</a> all lead to QTS or PGCE/PGDE plus QTS.
+</p>
+<p>
+	The majority of postgraduate teacher training courses are made up of:
+</p>
+<ul>
+	<li>academic study of the theory of teaching (also known as ‘pedagogy’)
+	<li>hands-on experience in the classroom</li>
+</ul>
+<p>
+	The course typically lasts a year (3 school terms) and training will usually take place:
+</p>
+<ul>
+	<li>at your training provider's main site
+	<li>in school placements organised by your provider</li>
+</ul>
+<p>
+	Details of course structure and location will vary between training providers –
+	you can research specific courses on <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses" target="_blank" rel="noopener noreferrer">Find postgraduate teacher training</a>.
+</p>
+<p>
+	When you’re researching training providers, bear in mind:
+</p>
+<ul>
+	<li>location – you will need to be able to travel to your academic learning
+		location as well as your placement schools
+	<li>reputation – check Ofsted’s report on your training provider for more detail
+	<li>competition for entry – some providers are tougher than others
+	<li>special academic requirements for entry – check the training provider
+		listing in <a
+			href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
+		postgraduate teacher training</a> to see what class of degree, for example, the
+		provider asks for
+	<li>size of institution – would you be happier in a large university campus, or
+		in a smaller local school setting?
+	</li>
+</ul>
+<p>
+	You can use<a
+		href="https://www.gov.uk/find-postgraduate-teacher-training-courses"> Find
+	postgraduate teacher training</a> to find and compare a shortlist of training
+	providers located near to you.
+</p>
+		
+		
+<h2 id="things-to-consider">
+	Things to consider before you apply
+</h2>
+		
+		
+<h3 id="choose-an-age-group">
+	Choose an age group
+</h3>
+<p>
+	You can train to teach:
+</p>
+<ul>
+	<li>under-fives (also known as ‘early years’)</li>
+	<li>primary school children</li>
+	<li>primary school with a specialism (for example, English, modern languages or
+		science)</li>
+	<li>secondary school age children (you’ll need to specialise in a subject)</li>
+	<li>further education (14 to adult)</li>
+</ul>
+<p>
+	Use <a
+		href="https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2">Find postgraduate teacher training</a> to see the full list of options.
+</p>
+<p>
+	Or you could arrange to spend time in school to <a href="https://schoolexperience.education.gov.uk/">get experience of different age groups.</a>
+</p>
+<h3 id="teaching-under-fives">
+	Teaching under-fives
+</h3>
+<p>
+	If you choose to teach under-fives, you’ll need to apply for a specialist
+	teacher training course called Early Years Initial Teacher Training (EYITT).
+</p>
+<p>
+	At the end of the course, you’ll gain Early Years Teacher Status and will be
+	qualified to teach under-fives only.
+</p>
+<div role="note" aria-label="Information" class="application-notice info-notice">
+  <p>Please note these courses do not lead to Qualified Teacher Status (QTS).</p>
+</div>
+<p>
+	<a
+		href="https://www.gov.uk/government/publications/early-years-initial-teacher-training-itt-providers-and-school-direct-early-years-lead-organisations/early-years-initial-teacher-training-itt-providers-and-school-direct-lead-organisations">Browse a list of training providers offering Early Years Teacher Training</a>
+</p>
+<p>
+	EYITT courses are eligible for bursaries, scholarships and student finance. Some are also salaried.
+</p>
+<p>
+	Undergraduate courses:
+</p>
+<ul>
+	<li>take 3 to 4 years of full-time study and lead to a degree in an early</li>
+		childhood-related subject
+	<li>have tuition fee loans available from <a
+		href="https://www.gov.uk/student-finance">Student Finance England (SFE)</a>.</li>
+</ul>
+<p>
+	Graduate entry courses:
+</p>
+<ul>
+	<li>typically take one year of full-time study</li>
+	<li>provide a £7,000 grant to cover course fees</li>
+	<li>offer bursaries for graduates up to £5,000 for a first class degree</li>
+</ul>
+<p>
+	Graduate employment-based courses:
+</p>
+<ul>
+	<li>are one year part-time courses for graduates working in early years settings
+		who need further training to demonstrate the Teachers’ Standards (Early Years)</li>
+	<li> offer funding of £14,000 to cover up to £7,000 fees and £7,000 contribution
+		to employer costs</li>
+</ul>
+<p id="assessment-only">
+	Assessment Only is:
+</p>
+<ul>
+	<li>self-funded</li>
+	<li>maximum of 3 months duration</li>
+	<li>ideal for graduates with experience of working with children from birth age
+		to 5, who meet the Teachers’ Standards (Early Years) and have no need for further training
+	</li>
+</ul>
+
+<h3 id="choose-a-subject">
+	Choose a subject
+</h3>
+<p>
+	<a
+		href="https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2">View
+	a list of secondary school teaching subjects</a>
+</p>
+<p>
+	When you apply for teacher training, you’ll be asked to give detailed evidence
+	for the knowledge and interest you bring to the subject(s) you’d like to teach.
+</p>
+<p>
+	Evidence can include:
+</p>
+<ul>
+	<li>the subject of your undergraduate degree</li>
+	<li>modules you studied as part of your degree</li>
+	<li>postgraduate degrees (for example, a Masters or PhD)</li>
+	<li>your A level subjects</li>
+	<li>expertise you’ve gained at work</li>
+</ul>
+<h3 id="subject-knowledge-enhancement-courses">Subject knowledge enhancement (SKE) courses</h3>
+		
+		<p>SKE courses are intended to help you enhance your knowledge so that you're able to teach a subject.</p>
+		<p>Your training provider will identify if you need to take one as part of their selection process, usually at interview.</p> 
+	      <p>They will ask you to complete an SKE course as a condition of taking up your offer of a teacher training place if they feel you need to enhance your subject knowledge.</p>
+		
+		<p>SKE courses are usually available if:</p>
+		<ul>
+			<li>your degree isn't in your chosen subject</li>
+			<li>you studied the subject at A level but not degree level </li> 
+			<li>you have an unrelated degree, but relevant professional experience in the subject</li>
+		</ul>
+		
+		<p>SKE courses can also be helpful if it’s been a while since you studied for your degree.</p>
+		
+<div role="note" aria-label="Information" class="application-notice info-notice">
+  <p>Please note that SKE courses for candidates starting Initial Teacher Training (ITT) in 2021/22 will not be available at the start of the recruitment cycle from 1 October 2020.</p>
+  <p>We will confirm the approach to SKEs following completion of the government's Spending Review.</p>
+  <p>ITT providers will be able to offer a teacher training place under the condition of completing an SKE course, but you won't be able to start one until funding and eligibility are confirmed after the Spending Review has been completed.</p>
+  <p>You should note that a conditional offer does not guarantee a funded SKE course will be available in your chosen subject.</p>		
+</div>
+
+
+
+<p>
+	You won't have to pay for your SKE course and you may be eligible for a bursary.
+</p>
+<p>
+	Your training provider will decide the course duration (between 8 and 28 weeks). This will depend on the knowledge you need. 
+</p>
+<p>
+	SKE courses can be completed before or, in some cases, alongside your teacher training. They are available to study full-time or part-time, classroom-based or online. 
+</p>
+<p>
+	SKE courses are usually available in:
+</p>
+<ul>
+	<li>biology</li>
+	<li>chemistry</li>
+	<li>computer studies</li>
+	<li>design and technology</li>
+	<li>English</li>
+	<li>geography</li>
+	<li>languages</li>
+	<li>maths</li>
+	<li>physics</li>
+	<li>primary maths</li>
+	<li>religious education</li>
+</ul>
+<p>The SKE directory sets out what courses are provided and will be updated once we have confirmed the approach to SKE courses for academic year 2020/21</p>
+		
+<p>
+	If you’re concerned about your subject knowledge, discuss it with your potential training providers.
+</p>
+		
+
+
+<h2 id="training-to-teach-if-you-have-a-disability">Training to teach if you have a disability</h2>
+<p>Teachers with disabilities make valuable contributions both to classrooms and the culture of schools where they work.
+</p>
+<h4>Your rights</h4>
+<p>
+	It is against the law for teacher training providers to discriminate against teacher training candidates with disabilities. Under the Equality Act 2010, providers must make adjustments to help you do a course or go to an interview, providing your requests are reasonable. Examples of support could be:
+</p>
+<ul>
+	<li>organising equipment like a hearing loop or an adapted keyboard</li>
+	<li>putting you in touch with support staff if you have a mental health
+		condition</li>
+	<li>making sure classrooms are wheelchair accessible</li>
+</ul>
+<p>
+	If the help you need is not covered by your provider making adjustments, you
+	might also be able to get support from <a
+		href="https://www.gov.uk/access-to-work">Access to Work</a>. This could include
+	a grant to help cover the costs of practical support in the workplace.
+</p>
+<h4>Telling your training provider about your disability when you apply</h4>
+  
+  <p>It’s up to you if you want to tell your training
+	provider about your disability. </p>
+  <p>information you give about your
+	disability is protected under the <a
+		href="https://www.gov.uk/data-protection/the-data-protection-act">Data
+  Protection Act 2018</a>.</p>
+  <h4>Completing a fitness questionnaire</h4>
+  <p>If you’re offered a place on a teacher
+	training course, you may have to complete a fitness questionnaire before
+	starting. Training providers should only ask relevant questions to make sure
+  you’re able to teach.</p>
+  <h4>Useful resources for disabled candidates</h4>
+
+<p><a
+	href="https://www.gov.uk/disabled-students-allowances-dsas">Get funding help if
+	you're a student with a learning difficulty, health problem or
+	disability</a>
+</p>
+
+<p><a href="http://www.equalityhumanrights.com/en">The Equality and
+	Human Rights Commission (EHRC)</a> for information about discrimination on the
+  grounds of disablity.</p>
+<p><a href="http://www.abilitynet.org.uk/">AbilityNet</a> for advice on the use of
+	computers and communication technology for disabled
+  people.</p>
+<p><a
+		href="http://www.disabilityrightsuk.org/adjustments-disabled-students">Disability
+	Rights UK</a> for advice on adjustments for disabled students while
+	studying.
+</p>		
+		
+		
+<h2 id="high-potential">High potential candidates, career changers and researchers</h2>
+		
+		<h3 id="high-potential-itt">High Potential ITT</h3>
+	  <p><a href="https://www.teachfirst.org.uk/">Teach First</a> is a charity which runs the government-funded High Potential Initial Teacher Training programme (ITT). You’ll need to have a 2:1 degree or higher to apply for a place on the programme, currently delivered by Teach First. You’ll train over 2 years by learning on the job, paid as an unqualified teacher and you will not pay tuition fees.</p> 
+	  <p>You’ll be placed into a school straight away and gain QTS in your first year and complete your Newly Qualified Teacher placement in year 2. You’ll also receive leadership training, which includes a fully-funded Postgraduate Diploma in Education and Leadership (PGDE), worth double the credits of a PGCE.</p>
+
+
+<h3 id="career-changers">Career Changers</h3>
+<p>The Career Changers programme aims to attract high calibre graduates who have had a successful professional career with significant experience in their field into  teaching roles and schools where they are needed most.</p>
+		<p>It provides help and guidance with the transition from a previous career into teaching.</p> <p> Career changers can add value to teaching with:</p>
+<ul>
+	<li>previous employment experience</li>
+	<li>industry knowledge</li>
+	<li>wider perspectives into teaching practice and school policies</li>
+</ul>
+</p>
+
+<p><a href="https://nowteach.org.uk/">Now Teach (NT)</a> and <a href="https://www.transitiontoteach.co.uk/">Transition to Teach (TT)</a> are bespoke teacher recruitment and retention programmes developed exclusively to support career changers, providing transitional support and additional mentoring so that successful career changers can get the most out of their transition to teaching.</p>
+
+
+
+<h3 id="researchers-in-schools">Researchers in Schools (candidates with a doctorate)
+</h3>
+<p>Researchers in Schools, which includes the Maths and Physics Chairs programme, is a tailored, teacher training and professional development course for high-calibre candidates.</p>
+<p>The programme is designed to run over 3 years, and offers both a salaried and bursary route into teacher training depending on your prior experiences and circumstances. </p>
+<p>
+	To <a href="https://researchersinschools.org/">apply to this teacher training
+	programme</a>, you'll need (or be about to finish) a doctorate in one of the following subjects:
+</p>
+<ul>
+	<li>physics</li>
+	<li>mathematics</li>
+	<li>chemistry</li>
+	<li>biology</li>
+	<li>engineering</li>
+	<li>computing</li>
+	<li>English</li>
+	<li>history</li>
+	<li>classics (Latin or Greek)</li>
+	<li>modern foreign languages (French, German or Spanish)</li>
+</ul>
+
 <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
   <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
   </svg>Back to top
 </a>
-	 
-	  <h2 id="disabled-students">Disabled students - extra financial support</h2>
-<p>If you have additional needs due to a mental health condition, long-term illness or disability you can apply for <a href="https://www.gov.uk/disabled-students-allowances-dsas/how-to-claim" target="_blank">Disabled Students’ Allowances (DSAs)</a>.</p>
 
-		
+<h2 id="teaching-children-with-special-educational-needs-and-or-disabilities-SEND">
+	Teaching children with special educational needs and disabilities (SEND)
+</h2>
+<p>
+	Use <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find
+	postgraduate teacher training</a> to search for training courses that involve working with SEND children.
+</p>
+<p>
+	Qualified SEND teachers are eligible for an extra payment, on top of their
+	annual salary, of between £2,209 and £4,359 a year.
+</p>
+<h4>Teaching SEND pupils</h4>
+<p>You don’t have to take a SEND specialist course. If you want to be a SEND teacher you can apply to teach in a special school if you have:</p>
+<ul>
+	<li>been teaching for a few years</li>
+	<li>experience of managing SEND pupils in your primary or secondary school</li>
+</ul>
 
-  <h2 id="find-train-to-teach-event">Find a Train To Teach event near you</h2>
+<h4>Teaching children with sensory impairments</h4>
+<p>If you want to teach pupils with hearing, vision or multi-sensory impairments, you’ll need a specific qualification. </p>
+<h4>Be a Special Educational Needs Coordinator (SENCo)</h4>
+<p>As a SENCo you’ll be responsible for assessing, planning and monitoring the progress of children with SEND. To apply for a job as a SENCo, you’ll need to:</p>
+<ul>
+	<li>be a qualified teacher</li>
+	<li>complete the National Award in Special Educational Needs Coordination (NASENCO) when you take up the SENCO post</li>
+</ul>
+
+<a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+  </svg>Back to top
+</a>
+
+	
+<h2 id="get-a-job-in-teaching">
+	Get a job in teaching
+</h2>
+<p>
+	You can find teaching jobs by searching the Department for Education’s <a
+		href="https://teaching-vacancies.service.gov.uk/">Teaching Vacancies</a>
+	service.
+</p>
+<p>
+	The service is used by 70% of state schools in England. Search by location,
+	subject, job title and salary and set up job alerts.
+</p>
+<a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+  </svg>Back to top
+</a>
+
+
+<h2 id="contact-and-support">
+	Contact and support
+</h2>
+<h3>
+	Chat online
+</h3>
+<p>
+	Contact Get into
+	Teaching’s live <a href="/#talk-to-us">online chat service</a> between 8.30am and 5pm, Monday to Friday.
+</p>
+	<h3>Speak on the phone</h3>
+
+<p>
+	You can call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a> between 8.30am and 5pm,
+	Monday to Friday.
+</p>
+
+  <h3>Find an event near you</h3>
   <p>
   <a href="events"  target="_blank" rel="noopener noreferrer">Get Into Teaching’s nationwide
 	  events</a> are informal opportunities for you to get free expert advice about your
 	next steps into teaching.
 </p>
-
-	  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+<a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
   <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
   </svg>Back to top
 </a>
-	  
-<h2 id="help-and-support">
-	Contact and support
-</h2>
-
-<p>
-	Contact Get into
-	Teaching’s live <a href="/#talk-to-us">online chat service</a> between 8.30am and 5pm, Monday to Friday.
-</p>
-	
-<p>
-	Call us about teaching or teacher training on Freephone <a href="tel:08003892501" class="telephone-number" aria-label="Telephone">0800 389 2501</a> between 8.30am and 5pm,
-	Monday to Friday.
-</p>
+<h2 id="further-support-and-information">Further support and information</h2>
 
 <p>Send an email to:
-<a href="mailto:getintoteaching.helpdesk@education.gov.uk" class="govuk-link">getintoteaching.helpdesk@education.gov.uk</a>.</p>
+<a href="mailto:getintoteaching.helpdesk@education.gov.uk" class="govuk-link">getintoteaching.helpdesk@education.gov.uk</a>
+ or call Freephone 0800 389 2501.</p>
 
 </div>
 </div>
-	  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
-  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-  </svg>Back to top
-</a>
 
 
   <div class="responsive-bottom-margin">
@@ -593,7 +945,7 @@
   <ul class="gem-c-related-navigation__link-list" data-module="track-click">
 
 
-   <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" href="/">Get Into Teaching</a></li>
+   <li class="gem-c-related-navigation__link"><a class="gem-c-related-navigation__section-link gem-c-related-navigation__section-link--footer" href="https://beta-getintoteaching.education.gov.uk">Get Into Teaching</a></li>
 
   </ul>
 </nav>


### PR DESCRIPTION
Changed finance-guidance and ways-to-train-guidance file names to financial-support-for-teacher-training and train-to-become-a-teacher and all associated links on other site pages.



