### PR TITLE
Switch the stories landing page to frontmatter

### DIFF
--- a/content/life-as-a-teacher/my-story-into-teaching.md
+++ b/content/life-as-a-teacher/my-story-into-teaching.md
@@ -1,293 +1,130 @@
 ---
-title: "My story into teaching"
-image: "/assets/images/my-story-hero-dt.jpg"
-mobileimage: "/assets/images/my-story-hero-mob.jpg"
-backlink: "../../"
+title: My story into teaching
+image: /assets/images/my-story-hero-dt.jpg
+mobileimage: /assets/images/my-story-hero-mob.jpg
 hide_page_helpful_question: true
 navigation: 35
 fullwidth: true
+featured_story:
+  image: /assets/images/victoria.png
+  name: Victoria
+  heading: Bring your professional skills to the classroom
+  subheading: Victoria Barton, teacher and former police officer
+  text: >
+    In addition to 2 Master’s degrees, Victoria’s career had included
+    time working as a police officer and property inspector. Find out
+    why she decided to bring that diverse experience to teaching as a
+    primary PE specialist.
+  link: /life-as-a-teacher/my-story-into-teaching/career-changers/police-officer-to-pe-teacher
+sections:
+  Changing career:
+    link: my-story-into-teaching/career-changers
+    text: >
+      If you are thinking of changing your career, you’re in good company. Every
+      year, many people decide to move from other careers into teaching. You can see
+      people who’ve chosen to switch career and make a difference to young people’s
+      lives.
+    stories:
+      - name: Will
+        link: /life-as-a-teacher/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching
+        image: /assets/images/stories/stories-will.jpg
+        snippet: Transferring my skills to teaching
+      - name: Peter
+        link: /life-as-a-teacher/my-story-into-teaching/career-changers/financiers-future-in-maths
+        image: /assets/images/stories/stories-peter.jpg
+        snippet: Financier's future in maths
+      - name: Zainab
+        link: /life-as-a-teacher/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
+        image: /assets/images/stories/stories-zainab.jpg
+        snippet: School experience helped me decide to switch
+  International returning teachers:
+    link: my-story-into-teaching/international-career-changers
+    text: >
+      It’s a great time to train to teach, with a wide array of training
+      options and support available. Find out what you can expect from current
+      trainees and teachers.
+    stories:
+      - name: Katie
+        link: /life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
+        image: /assets/images/stories/stories-katie.png
+        snippet: Returning to teaching with international experience
+      - name: Shaun
+        link: /life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
+        image: /assets/images/stories/stories-shaun.jpg
+        snippet: Returning to teaching with support from an adviser
+  Teacher training:
+    link: my-story-into-teaching/teacher-training
+    text: >
+      It’s a great time to train to teach, with a wide array of training
+      options and support available. Find out what you can expect from current
+      trainees and teachers.
+    stories:
+      - name: Emma
+        link: /life-as-a-teacher/my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss
+        image: /assets/images/stories/stories-emma.png
+        snippet: Why don’t you teach, Miss?
+      - name: Hasina
+        link: /life-as-a-teacher/my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it
+        image: /assets/images/stories/stories-generic.jpg
+        snippet: "Teacher training: it’s worth it"
+      - name: Nathan
+        link: /life-as-a-teacher/my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning
+        image: /assets/images/stories/stories-nathan.jpg
+        snippet: "Salaried teacher training: classroom learning"
+  Making a difference:
+    link: my-story-into-teaching/making-a-difference
+    text: >
+      Teachers talk about making a real difference to pupils’ learning and
+      lives - and the job satisfaction that comes with a career in teaching.
+      Find out how these teachers are helping pupils realise their ambitions,
+      and enjoying every moment.
+    stories:
+      - name: Danny
+        link: /life-as-a-teacher/my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success
+        image: /assets/images/stories/stories-danny.jpg
+        snippet: Turning a tough lesson into a success
+      - name: Sandra
+        link: /life-as-a-teacher/my-story-into-teaching/making-a-difference/going-back-and-giving-back
+        image: /assets/images/stories/stories-sandra.jpg
+        snippet: Going back and giving back
+      - name: Gavin
+        link: /life-as-a-teacher/my-story-into-teaching/making-a-difference/no-two-days-are-the-same
+        image: /assets/images/stories/stories-gavin.jpg
+        snippet: No two days are the same
+  Career progression:
+    link: my-story-into-teaching/career-progression
+    text: >
+      Teachers talk about making a real difference to pupils’ learning and
+      lives - and the job satisfaction that comes with a career in teaching.
+      Find out how these teachers are helping pupils realise their ambitions,
+      and enjoying every moment.
+    stories:
+      - name: Paul
+        link: /life-as-a-teacher/my-story-into-teaching/career-progression/grasp-every-opportunity
+        image: /assets/images/stories/stories-paul.jpg
+        snippet: Grasp every opportunity
+      - name: Paul
+        link: /life-as-a-teacher/my-story-into-teaching/career-progression/nqt-to-head-of-biology
+        image: /assets/images/stories/stories-sarah-f.jpg
+        snippet: NQT to head of biology in 2 years
+      - name: Jon
+        link: /life-as-a-teacher/my-story-into-teaching/career-progression/leaping-to-head-of-department
+        image: /assets/images/stories/stories-jon.jpg
+        snippet: Leaping to head of department
+  Returning to teaching:
+    link: my-story-into-teaching/returners
+    text: >
+      Teachers talk about making a real difference to pupils' learning and
+      lives - and the job satisfaction that comes with a career in teaching.
+      Find out how these teachers are helping pupils realise their ambitions,
+      and enjoying every moment.
+    stories:
+      - name: Jill
+        link: /life-as-a-teacher/my-story-into-teaching/returners/getting-back-into-the-classroom
+        image: /assets/images/stories/stories-jill.png
+        snippet: Getting back into the classroom
+      - name: Helen
+        link: /life-as-a-teacher/my-story-into-teaching/returners/top-tips-for-returning-teachers
+        image: /assets/images/stories/stories-helen.jpg
+        snippet: Top tips for returning teachers
 ---
-
-<div class="stories-feature">
-    <div class="stories-feature__image" style="background-image:url('/assets/images/victoria.png')"></div>
-    <div class="stories-feature__content">
-        <h2>Bring your professional skills to the classroom</h2>
-        <h3>Victoria Barton, teacher and former police officer</h3>
-        <p>
-            In addition to 2 Master’s degrees, Victoria’s career had included time working as a police officer and property inspector. Find out why she decided to bring that diverse experience to teaching as a primary PE specialist.
-        </p>
-        <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/police-officer-to-pe-teacher">Read Victoria’s story <i class="fas fa-chevron-right"></i></a>
-    </div>
-</div>
-
-<div class="container-1000">
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>Changing career</h2>
-            <p>
-                <br/>
-                If you are thinking of changing your career, you’re in good company. Every year, many people decide to move from 
-                other careers into teaching. You can see people who’ve chosen to switch career and make a difference to young people’s lives.
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-will.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Transferring my skills to teaching</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching">Read Will's story<i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-changers/financiers-future-in-maths">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-peter.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Financier's future in maths</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/financiers-future-in-maths">Read Peter's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-zainab.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>School experience helped me decide to switch</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch">Read Zainab's story <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/career-changers" class="call-to-action-button stories-call-to-action">
-                Read all stories about changing career
-            </a>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>International returning teachers</h2>
-            <p>
-                <br/>
-                See how already qualified teachers' returned to England from abroad, to get back into the profession.
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-katie.png')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Returning to teaching with international experience</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience">Read Katie's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-shaun.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Returning to teaching with support from an adviser</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser">Read Shaun's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/international-career-changers" class="call-to-action-button stories-call-to-action">
-                Read all stories about international returning teachers
-            </a>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>Teacher training </h2>
-            <p>
-                <br/>
-                It’s a great time to train to teach, with a wide array of training options and support available. Find out what you can expect
-                from current trainees and teachers. 
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-emma.png')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Why don’t you teach, Miss?</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss">Read Emma's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-generic.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Swapping senior management for students</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it">Read Hasina's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-nathan.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Salaried teacher training: classroom learning</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning">Read Nathan's story <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/teacher-training-stories" class="call-to-action-button stories-call-to-action">
-                Read all stories about teacher training
-            </a>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>Making a difference</h2>
-            <p>
-                <br/>
-                Teachers talk about making a real difference to pupils’ learning and lives - and the job satisfaction that comes with a career
-                in teaching. Find out how these teachers are helping pupils realise their ambitions, and enjoying every moment.
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-danny.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Turning a tough lesson into a success</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success">Read Danny's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/going-back-and-giving-back">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images//stories/stories-sandra.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Going back and giving back</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/going-back-and-giving-back">Read Sandra's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/no-two-days-are-the-same">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-gavin.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>No two days are the same</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/making-a-difference/no-two-days-are-the-same">Read Gavin's story <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/making-a-difference" class="call-to-action-button stories-call-to-action">
-                Read all stories about making a <span> difference</span>
-            </a>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>Career progression</h2>
-            <p>
-                <br/>
-                Teachers talk about making a real difference to pupils’ learning and lives - and the job satisfaction that comes with a career
-                in teaching. Find out how these teachers are helping pupils realise their ambitions, and enjoying every moment.
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-progression/grasp-every-opportunity">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-paul.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Grasp every opportunity</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-progression/grasp-every-opportunity">Read Paul's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-progression/nqt-to-head-of-biology">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-sarah-f.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>NQT to head of biology in 2 years</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-progression/nqt-to-head-of-biology">Read Sarah's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/career-progression/leaping-to-head-of-department">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-jon.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Leaping to head of department</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/career-progression/leaping-to-head-of-department">Read Jon's story <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/career-progression" class="call-to-action-button stories-call-to-action">
-                Read all stories about career <span> progression</span>
-            </a>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <h2>Returning to teaching</h2>
-            <p>
-                <br/>
-                Teachers talk about making a real difference to pupils' learning and lives - and the job satisfaction that comes with a career
-                in teaching. Find out how these teachers are helping pupils realise their ambitions, and enjoying every moment.
-            </p>
-        </div>
-    </div>
-    <div class="more-stories">
-        <div class="more-stories__thumbs">
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/returners/getting-back-into-the-classroom">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-jill.png')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Getting back into the classroom</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/returners/getting-back-into-the-classroom">Read Jill's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-            <div class="more-stories__thumbs__thumb">
-                <a href="/life-as-a-teacher/my-story-into-teaching/returners/top-tips-for-returning-teachers">
-                    <div class="more-stories__thumbs__thumb__img" style="background-image:url('/assets/images/stories/stories-helen.jpg')"></div>
-                </a>
-                <div class="more-stories__thumbs__thumb__content">
-                    <p>Top tips for returning teachers</p>
-                    <a class="git-link" href="/life-as-a-teacher/my-story-into-teaching/returners/top-tips-for-returning-teachers">Read Helen's story  <i class="fas fa-chevron-right"></i></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content-wrapper">
-        <div class="content__left">
-            <a href="/life-as-a-teacher/my-story-into-teaching/returners" class="call-to-action-button stories-call-to-action">
-                Read all stories about returning to teaching
-            </a>
-        </div>
-    </div>
-</div>


### PR DESCRIPTION
Similar to the previous HTML to Markdown PRs, this is related to the following ticket in the main app. The HTML has been entirely removed and the page can now be fully built using the provided frontmatter.

See DFE-Digital/get-into-teaching-app/pull/513
