### PR TITLE
Wrap the last word of link text in .link-chevron

### DIFF
--- a/content/home/featured_content/_apply_for_teacher_training.html.erb
+++ b/content/home/featured_content/_apply_for_teacher_training.html.erb
@@ -3,6 +3,9 @@
     <div class="featured-content__image" style="background-image: url('assets/images/home-steps.jpg')"></div>
     <div class="featured-content__content">
         <span>Applications to teacher training courses starting in autumn 2021 are open now.</span>
-        <a class="featured-content__link" href="https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher">Steps to become a teacher</a>
+        <a class="featured-content__link" href="https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher">
+          Steps to become a
+          <span class="link-chevron">teacher</span>
+        </a>
     </div>
 </div>

--- a/content/home/featured_content/_swapping_senior_management_for_students.html.erb
+++ b/content/home/featured_content/_swapping_senior_management_for_students.html.erb
@@ -9,6 +9,8 @@
     </a>
     <div class="featured-content__content">
         <span> I was a director of a large market research agency, but I had always always harboured a long-term ambition to teach.</span>
-        <a class="featured-content__link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/swapping-senior-management-for-students">Read Karen’s story </a>
+        <a class="featured-content__link" href="/life-as-a-teacher/my-story-into-teaching/career-changers/swapping-senior-management-for-students">
+          Read Karen’s <span class="link-chevron">story</span>
+        </a>
     </div>
 </div>

--- a/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
+++ b/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
@@ -9,6 +9,8 @@
     </a>
     <div class="featured-content__content">
         <span>Our dedicated, experienced teaching professionals can help you prepare a strong teacher training application.</span>
-        <a class="featured-content__link" href="https://beta-adviser-getintoteaching.education.gov.uk/">Get help with your application</a>
+        <a class="featured-content__link" href="https://beta-adviser-getintoteaching.education.gov.uk/">
+          Get help with your <span class="link-chevron">application</span>
+        </a>
     </div>
 </div>


### PR DESCRIPTION
This allows us to target it with CSS and prevent the chevron from wrapping on its own. This is associated with DFE-Digital/get-into-teaching-app/pull/538

