### PR TITLE
Fix button classes for Govspeak context

### DIFF
--- a/content/guidance/financial-support-for-teacher-training.md
+++ b/content/guidance/financial-support-for-teacher-training.md
@@ -83,7 +83,7 @@ provider.
 
 <p>Talk to us between 8.30am and 5pm, Monday to Friday if you have questions or need advice about bursaries.  </p>
 
-<p><a class="govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
+<p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
 
 <p>Alternatively, call Freephone 0800 389 2501 .</p>
 
@@ -169,7 +169,7 @@ provider.
 
 <p>Talk to us between 8.30am and 5pm, Monday to Friday if you have questions or need advice about scholarships.  </p>
 
-<p><a class="govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
+<p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
 
 <p>Alternatively, call Freephone 0800 389 2501 .</p>
 
@@ -234,7 +234,7 @@ into teaching.
 
 <p>Talk to us between 8.30am and 5pm, Monday to Friday about teaching or teacher training.  </p>
 
-<p><a class="govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
+<p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
 
 <p>Alternatively, call Freephone 0800 389 2501 or email:<a href="mailto:getintoteaching.helpdesk@education.gov.uk">getintoteaching.helpdesk@education.gov.uk</a></p>
 

--- a/content/guidance/train-to-become-a-teacher.md
+++ b/content/guidance/train-to-become-a-teacher.md
@@ -514,7 +514,7 @@ location, subject, job title and salary and set up job alerts.
 
 <p>Talk to us between 8.30am and 5pm, Monday to Friday about teaching or teacher training.  </p>
 
-<p><a class="govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
+<p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
 
 <p>Alternatively, call Freephone 0800 389 2501 or email:<a href="mailto:getintoteaching.helpdesk@education.gov.uk"></p>
 


### PR DESCRIPTION
As these guidance pages are picking up their style info from Govspeak rather than plain old GOV.UK Design System, we need to tweak them a bit by adding `gem-c-button` in. There's a full explanation of the styling options here, but as we're not using the full gem we need the generated markup not the source markdown.

https://govspeak-preview.herokuapp.com/guide
