### PR TITLE
An unclosed anchor tag breaks the following text

### DIFF
--- a/content/guidance/train-to-become-a-teacher.md
+++ b/content/guidance/train-to-become-a-teacher.md
@@ -513,11 +513,8 @@ location, subject, job title and salary and set up job alerts.
 <div class="call-to-action">
 
 <p>Talk to us between 8.30am and 5pm, Monday to Friday about teaching or teacher training.  </p>
-
-<p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
-
-<p>Alternatively, call Freephone 0800 389 2501 or email:<a href="mailto:getintoteaching.helpdesk@education.gov.uk"></p>
-
+  <p><a class="gem-c-button govuk-button" data-module="govuk-button" href="https://beta-getintoteaching.education.gov.uk/#talk-to-us">Chat online</a></p>
+  <p>Alternatively, call Freephone 0800 389 2501 or email: <a href="mailto:getintoteaching.helpdesk@education.gov.uk">getintoteaching.helpdesk@education.gov.uk</a></p>
 </div>
 
 ### Find an event near you
@@ -525,5 +522,3 @@ location, subject, job title and salary and set up job alerts.
 [Get Into Teaching’s nationwide events](events) are informal
 opportunities for you to get free expert advice about your next steps
 into teaching.
-
-


### PR DESCRIPTION
Quick fix, the unclosed `<a>` tag is making the remainder of the file not render properly.
