### PR TITLE
Make image paths absolute

### DIFF
--- a/content/home/featured_content/_apply_for_teacher_training.html.erb
+++ b/content/home/featured_content/_apply_for_teacher_training.html.erb
@@ -1,6 +1,6 @@
 <div class="featured-content__item">
     <span class="featured-content__title">Apply for teacher training.</span>
-    <div class="featured-content__image" style="background-image: url('assets/images/home-steps.jpg')"></div>
+    <div class="featured-content__image" style="background-image: url('/assets/images/home-steps.jpg')"></div>
     <div class="featured-content__content">
         <span>Applications to teacher training courses starting in autumn 2021 are open now.</span>
         <a class="featured-content__link" href="https://beta-getintoteaching.education.gov.uk/steps-to-become-a-teacher">

--- a/content/home/featured_content/_swapping_senior_management_for_students.html.erb
+++ b/content/home/featured_content/_swapping_senior_management_for_students.html.erb
@@ -1,7 +1,7 @@
 <div class="featured-content__item">
     <span class="featured-content__title">Swapping senior management for students.</span>
     <a href="https://www.youtube.com/watch?v=riY-1DUkLVk" target="_blank" data-action="click->video#play" data-target="video.link">
-        <div class="featured-content__image" style="background-image: url('assets/images/home-karen.jpg')">
+        <div class="featured-content__image" style="background-image: url('/assets/images/home-karen.jpg')">
             <div class="more-stories__thumbs__thumb__play">
                 <div class="icon-play"></div>
             </div>

--- a/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
+++ b/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
@@ -1,7 +1,7 @@
 <div class="featured-content__item">
     <span class="featured-content__title">Why sign up for a Teacher Training Adviser?</span>
      <a href="https://www.youtube.com/watch?v=vvY7m2YD0Vs" target="_blank" data-action="click->video#play" data-target="video.link">
-        <div class="featured-content__image" style="background-image: url('assets/images/home-tta.jpg')">
+        <div class="featured-content__image" style="background-image: url('/assets/images/home-tta.jpg')">
             <div class="more-stories__thumbs__thumb__play">
                 <div class="icon-play"></div>
             </div>


### PR DESCRIPTION
Now this partial is used in places other than the homepage the relative path cannot be relied on. Using absolute paths will allow the partial to be used anywhere.

