### PR TITLE
Fix the events link and make it not relative

### DIFF
--- a/content/guidance/financial-support-for-teacher-training.md
+++ b/content/guidance/financial-support-for-teacher-training.md
@@ -224,7 +224,7 @@ illness or disability you can apply for
 
 ## Find a Train To Teach event near you
 
-[Get Into Teaching’s nationwide events](events) are informal
+[Get Into Teaching’s nationwide events](/events) are informal
 opportunities for you to get free expert advice about your next steps
 into teaching.
 


### PR DESCRIPTION
This was broken by moving the guidance files to their own directory.

