### PR TITLE
Fix train to become a teacher links (now guidance)

### DIFF
--- a/content/steps-to-become-a-teacher/accordion/_check_your_qualifications.md
+++ b/content/steps-to-become-a-teacher/accordion/_check_your_qualifications.md
@@ -14,7 +14,7 @@ To study for ITT, you’ll need these qualifications or their equivalents:
 
 If you do not have the required GCSEs, you’ll need to show that you have an equivalent level of education.
 
-If your degree is not in the subject you want to teach, or it's been a while since you studied, you may be able to take a [subject knowledge enhancement (SKE) course](/train-to-become-a-teacher#subject-knowledge-enhancement-courses).
+If your degree is not in the subject you want to teach, or it's been a while since you studied, you may be able to take a [subject knowledge enhancement (SKE) course](/guidance/train-to-become-a-teacher#subject-knowledge-enhancement-courses).
 
 Here's what you need to do if you:
 

--- a/content/steps-to-become-a-teacher/accordion/_ways_to_train.md
+++ b/content/steps-to-become-a-teacher/accordion/_ways_to_train.md
@@ -5,7 +5,7 @@ You’ll need to make some key decisions about teaching before you decide how to
 * which teaching qualification you want to achieve
 * how long you want to train for
 
-[Find out more about different ways to train](/train-to-become-a-teacher)
+[Find out more about different ways to train](/guidance/train-to-become-a-teacher)
 
 ### Teaching children with special educational needs and disabilities (SEND)
 
@@ -13,4 +13,4 @@ All teaching courses with QTS include training on working with pupils with .
 
 You could also specialise in supporting children with SEND.
 
-[Find out how to specialise in SEND](/train-to-become-a-teacher#teaching-children-with-special-educational-needs-and-or-disabilities-SEND)
+[Find out how to specialise in SEND](/guidance/train-to-become-a-teacher#teaching-children-with-special-educational-needs-and-or-disabilities-SEND)


### PR DESCRIPTION
Minor link fixes, pages have since been moved to `/guidance`
