### PR TITLE
Make content page checks use tag instead of file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
         run: |-
           docker run -t --rm -e RAILS_ENV=test \
             ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }} \
-            rspec --format documentation spec/features/content_pages_spec.rb
+            rspec --format documentation --tag content
 
       - uses: hashicorp/setup-terraform@v1.2.1
         with:


### PR DESCRIPTION
This allows us to target the content checks but disable them from general runs, where they'll be considerably slower due to the link validator.

Refs DFE-Digital/get-into-teaching-app/pull/589