### PR TITLE
Added Labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+---
+
+Assets:
+  - assets/**/*
+
+Content:
+  - content/**/*
+
+Config:
+  - config/**/*
+
+Test:
+  - tests/**/*
+
+DevOps:
+  - terraform/**/*
+  - .github/**/*.yml
+
+Docker:
+  - Dockerfile 
+  - docker-run.sh

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,10 @@
+name: "Pull Request Labeler"
+on:
+   - pull_request_target
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
When A PR is created the labeler will attempt to assign it a label based upon what code has changed.  
This is useful in the DevOps environment as we are monitoring repositories as a team, identifying work the team could do if an individual is not available

