### PR TITLE
Run content pages check on PRs as well as master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,6 @@ jobs:
                       CONTENT_SHA=${{ steps.sha.outputs.short }}
 
       - name: Check Content pages
-        if: github.ref == 'refs/heads/master'
         run: |-
           docker run -t --rm -e RAILS_ENV=test \
             ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }} \


### PR DESCRIPTION
### Context

We should be checking pages are valid *before* we allow them to be merged, not *after* `master` is broken

### Changes proposed in this pull request

1. Take out the constraint to `master`



