### PR TITLE
Build Docker Image locally and run content checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
                       CONTENT_SHA=${{ steps.sha.outputs.short }}
 
       - name: Check Content pages
-        if: github.ref == 'refs/heads/master'
         run: |-
           docker run -t --rm -e RAILS_ENV=test \
             ${{ steps.sha.outputs.local }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@master
+        with:
+          driver-opts: network=host
         
       - name: Get Short SHA
         id: sha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ jobs:
   deploy:
     name: Build and deploy
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports: 
+          - 5000:5000
     needs: turnstyle 
     steps:
 
@@ -64,7 +69,9 @@ jobs:
         
       - name: Get Short SHA
         id: sha
-        run: echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
+        run: |
+              echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
+              echo ::set-output name=local::localhost:5000/${{env.DOCKERHUB_REPOSITORY}}:sha-$(echo $GITHUB_SHA | cut -c -7)
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -80,7 +87,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
           
-      - name: Build only
+      - name: Build Locally
         uses: docker/build-push-action@v2
         if: github.ref != 'refs/heads/master'
         with:
@@ -88,8 +95,8 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
-                 ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }}
-          push: false
+                ${{ steps.sha.outputs.local }}
+          push: true
           build-args: |
                       CONTENT_SHA=${{ steps.sha.outputs.short }}
 
@@ -102,6 +109,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           tags: |
                  ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }}
+                 ${{ steps.sha.outputs.local }}
           push: true
           build-args: |
                       CONTENT_SHA=${{ steps.sha.outputs.short }}
@@ -110,7 +118,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |-
           docker run -t --rm -e RAILS_ENV=test \
-            ${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short }} \
+            ${{ steps.sha.outputs.local }} \
             rspec --format documentation spec/features/content_pages_spec.rb
 
       - uses: hashicorp/setup-terraform@v1.2.1


### PR DESCRIPTION
### Problem
When a change is committed on a branch the workflow does not run the content checks

### Solution
Build the docker image and push to a local repository, then run tests against the local build. This does not add anymore time to the process as we are just preserving the image for the next step. 
The same image is pushed to Docker hub as preserved locally on master builds.

### Review Notes
Runs without error

