### PR TITLE
Fixed invalid links on steps-to-become-a-teacher page

### DIFF
--- a/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.md
+++ b/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.md
@@ -1,7 +1,7 @@
 There are many ways to find out what subject you want to teach, whether you want to teach in a primary or secondary school or even in a college. 
 
-[Teaching as a career](teaching_as_a_career)
+[Teaching as a career](/teaching-as-a-career)
 
 Speaking with other teachers and finding out about different ways to train can help you find the best way for you to become a teacher. 
 
-[Come to an event](events) to chat with teachers, schools, trainee teachers and training providers.
+[Come to an event](/events) to chat with teachers, schools, trainee teachers and training providers.


### PR DESCRIPTION
There are a couple of invalid links on one of the steps to become a teacher sections

