### PR TITLE
Move ways to train to between steps and funding in navigation bar

### DIFF
--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -3,7 +3,7 @@
   image: "/assets/images/steps-hero-dt.jpg"
   mobileimage: "/assets/images/steps-hero-mob.jpg"
   backlink: "../"
-  navigation: 25
+  navigation: 15
   lid_pixel_event: "WaysToTrain"
   accordion:
     steps:


### PR DESCRIPTION
### Trello card

https://trello.com/c/Eez9czpc/601-develop-move-ways-to-train-on-top-nav-one-to-the-left

### Context

> Order should be:
> Home > Steps > Way to train > funding

### Changes proposed in this pull request

Move 'Ways to train' left

![Screenshot from 2020-12-07 10-46-59](https://user-images.githubusercontent.com/128088/101341945-bee7e980-3879-11eb-958a-fc487c1994c3.png)

### Guidance to review

Sensible?

