### PR TITLE
Update homepage steps to match steps page

### DIFF
--- a/content/home/_steps_home.html.erb
+++ b/content/home/_steps_home.html.erb
@@ -15,7 +15,7 @@
             <div class="steps__step">
                 <div class="steps__number"><span>2</span></div>
                 <a href="/steps-to-become-a-teacher#step-2" class="steps__link">
-                    <span>Find out about funding</span>
+                    <span>Find out about teaching and training</span>
                 </a>
             </div>
             <div class="steps__step">
@@ -33,7 +33,7 @@
             <div class="steps__step">
                 <div class="steps__number"><span>5</span></div>
                 <a href="/steps-to-become-a-teacher#step-5" class="steps__link">
-                    <span>Application process</span>
+                    <span>Find and apply for teacher training</span>
                 </a>
             </div>
           </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/s22xEK3n/617-homepage-event-image-quality-improve

### Context

The steps on the homepage and those on the steps page had fallen out of sync

### Changes proposed in this pull request

Rename the homepage steps to match their couterparts

### Guidance to review

Sense check

