### PR TITLE
Swapped ways to train and funding pages around in navigation

### DIFF
--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -3,7 +3,7 @@ title: "Funding your training"
 image: "/assets/images/funding-hero-dt.jpg"
 mobileimage: "/assets/images/funding-hero-mob.jpg"
 backlink: "../"
-navigation: 20
+navigation: 25
 lid_pixel_event: "Funding"
 jump_links:
   Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -3,7 +3,7 @@
   image: "/assets/images/steps-hero-dt.jpg"
   mobileimage: "/assets/images/steps-hero-mob.jpg"
   backlink: "../"
-  navigation: 25
+  navigation: 20
   lid_pixel_event: "WaysToTrain"
   accordion:
     steps:


### PR DESCRIPTION
### Context

The menu ordering should have ways to train ahead of the funding page

### Changes proposed in this pull request

1. Switched the priority of the navigation elements

### Guidance to review

Check the preview link in the comments when it appears

