### PR TITLE
Change stimulus target format for version 2.0.0

### DIFF
--- a/content/home/featured_content/_swapping_senior_management_for_students.html.erb
+++ b/content/home/featured_content/_swapping_senior_management_for_students.html.erb
@@ -1,5 +1,5 @@
 <div class="featured-content__item">
-    <a href="https://www.youtube.com/watch?v=riY-1DUkLVk" target="_blank" data-action="click->video#play" data-target="video.link">
+    <a href="https://www.youtube.com/watch?v=riY-1DUkLVk" target="_blank" data-action="click->video#play" data-video-target="link">
         <div class="featured-content__image" style="background-image: url('/assets/images/home-karen.jpg')">
             <div class="more-stories__thumbs__thumb__play">
                 <div class="icon-play"></div>

--- a/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
+++ b/content/home/featured_content/_why_sign_up_for_a_tta.html.erb
@@ -1,5 +1,5 @@
 <div class="featured-content__item">
-     <a href="https://www.youtube.com/watch?v=vvY7m2YD0Vs" target="_blank" data-action="click->video#play" data-target="video.link">
+     <a href="https://www.youtube.com/watch?v=vvY7m2YD0Vs" target="_blank" data-action="click->video#play" data-video-target="link">
         <div class="featured-content__image" style="background-image: url('/assets/images/home-tta.jpg')">
             <div class="more-stories__thumbs__thumb__play">
                 <div class="icon-play"></div>


### PR DESCRIPTION
This is related to DFE-Digital/get-into-teaching-app/pull/658

Essentially Stimulus 2.0.0 has changed the preferred format for `data-target` so that it includes the controller in the middle.