### PR TITLE
Switch image for one that's not used elsewhere

### DIFF
--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -1,6 +1,6 @@
 ---
   title: "Ways to train"
-  image: "/assets/images/steps-hero-dt.jpg"
+  image: "/assets/images/international-dt.jpg"
   mobileimage: "/assets/images/steps-hero-mob.jpg"
   backlink: "../"
   navigation: 20


### PR DESCRIPTION
The 'Steps to become a teacher' page and 'Ways to train' are next to
each other in the top nav and share the same image, it's potentially
confusing for users as there's not too much distinction between the
pages.

![Screenshot from 2020-12-15 11-51-37](https://user-images.githubusercontent.com/128088/102211750-faaf2e80-3ecb-11eb-8aed-89883ffd863d.png)


