### PR TITLE
Reword and reorganise the funding page

### DIFF
--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -1,68 +1,22 @@
 ---
-title: "Funding your training"
-image: "/assets/images/funding-hero-dt.jpg"
-mobileimage: "/assets/images/funding-hero-mob.jpg"
-backlink: "../"
-navigation: 25
-lid_pixel_event: "Funding"
-jump_links:
-  Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"
-  Bursaries and scholarships: "#bursaries-and-scholarships"
-  Get extra funding if you’re a parent, a carer or you have a disability: "#get-extra-financial-support-if-youre-a-parent-a-carer-or-you-have-a-disability"
-  Applying for funding if you come from outside England: "#applying-for-funding-if-you-come-from-outside-england"
+  title: "Funding your training"
+  image: "/assets/images/funding-hero-dt.jpg"
+  mobileimage: "/assets/images/funding-hero-mob.jpg"
+  backlink: "../"
+  navigation: 25
+  lid_pixel_event: "Funding"
+  jump_links:
+    Tuition fee and maintenance loans: "#tuition-fee-and-maintenance-loans"
+    Bursaries and scholarships: "#bursaries-and-scholarships"
+    Extra financial support for parents, carers or people with disabilities: "#extra-financial-support-for-parents-carers-or-people-with-disabilities"
+    Applying for funding if you come from outside England: "#applying-for-funding-if-you-come-from-outside-england"
+  content:
+    - content/funding-your-training/tuition-fee-and-maintenance-loans
+    - content/funding-your-training/tuition-fee-and-maintenance-loans-cta
+    - content/funding-your-training/bursaries-and-scholarships
+    - content/funding-your-training/bursaries-and-scholarships-cta
+    - content/funding-your-training/get-extra-financial-support
+    - content/funding-your-training/get-extra-financial-support-cta
+    - content/funding-your-training/applying-for-funding-if-you-come-from-outside-england
+    - content/funding-your-training/applying-for-funding-if-you-come-from-outside-england-cta
 ---
-
-You can apply for a tuition fee loan to pay for your training so you don't need to pay anything upfront. You can also apply for a maintenance loan to help with living costs and you may be able to get a bursary or a scholarship.
-
-## Tuition fee and maintenance loans
-
-Even if a bursary or scholarship is available for your course, you can get student finance to cover your fees and help with your living costs. You can apply for a tuition fee and/or a maintenance loan even if you already have a student loan.
-
-You can apply for a tuition fee loan of up to £9,250 to cover the full cost of your course fees and a maintenance loan of up to £12,010 to help with your living costs.
-
-You will only have to make repayments when you're earning. Your repayments will not increase if you already have a student loan and take a loan out for teacher training.
-
-[Find out more about tuition fee and maintenance loans](/guidance/financial-support-for-teacher-training#tuition-fee-and-maintenance-loans).
-
-Use the [student finance calculator on GOV.UK](https://www.gov.uk/student-finance-calculator) to find out how much you can get.
-
-## Bursaries and scholarships
-
-Bursaries and scholarships are tax-free amounts of money to train in certain subjects. You don’t need to pay them back.
-
-You’ll need a first, 2:1, 2:2 degree or a PhD or Master's to be eligible for a bursary.
-
-For a scholarship, each professional scholarship body sets its own criteria.
-
-You could get a bursary of up to £24,000 or apply for a scholarship of up to £26,000.
-
-[Find out more about bursaries and scholarships](/guidance/financial-support-for-teacher-training#introduction).
-
-## Get extra financial support if you’re a parent, a carer or you have a disability
-
-You may be able to get extra financial support if you have a disability, or if you have children or dependent adults. If you get this type of funding, you do not need to pay it back.
-
-You could apply for:
-
-* Disabled Students’ Allowance (DSA)
-* Childcare Grant
-* Parents Learning Allowance
-* Adult Dependants’ Grant
-
-Find out more about extra financial support for [parents and carers](/guidance/financial-support-for-teacher-training#parents-and-carers---extra-financial-support) and [people with disabilities](/guidance/financial-support-for-teacher-training#disabled-students---extra-financial-support).
-
-## Applying for funding if you come from outside England
-
-Whether you’re a home student (living in Wales, Scotland or Northern Ireland), an EU student or a student from outside the EU, you may still be eligible for funding to train to teach.
-
-If you live in [Wales](http://www.studentfinancewales.co.uk/), [Scotland](http://www.saas.gov.uk/) or [Northern Ireland](http://www.studentfinanceni.co.uk/) you’ll need to contact your country’s student finance body.
-
-Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or [Isle of Man](https://www.gov.im/student-grants).
-
-You could get a bursary or scholarship, student finance and extra funding to train to teach.
-
-If you’re an EU national starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance.
-
-[Read about funding for international students](/international-students#funding).
-
-If you come from outside England, you can get advice about training to be a teacher by using the online chat or Freephone number at the bottom of this page.

--- a/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england-cta.html.erb
+++ b/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england-cta.html.erb
@@ -1,0 +1,6 @@
+<%= render CallsToAction::SimpleComponent.new(
+  icon: "arrow-icon",
+  text: "If you come from outside England, you can get advice about training to be a teacher and find out more about coming to train in England.",
+  link_text: "Find out more",
+  link_target: "/international-candidates",
+) %>

--- a/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england.md
+++ b/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england.md
@@ -4,7 +4,7 @@ Whether you’re a home student (living in Wales, Scotland or Northern Ireland),
 
 If you live in [Wales](http://www.studentfinancewales.co.uk/), [Scotland](http://www.saas.gov.uk/) or [Northern Ireland](http://www.studentfinanceni.co.uk/) you’ll need to contact your country’s student finance body.
 
-Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or [Isle of Man](https://www.gov.im/student-grants).
+Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or on the [Isle of Man](https://www.gov.im/student-grants).
 
 You could get a bursary or scholarship, student finance and extra funding to train to teach.
 

--- a/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england.md
+++ b/content/funding-your-training/_applying-for-funding-if-you-come-from-outside-england.md
@@ -1,0 +1,11 @@
+## Applying for funding if you come from outside England
+
+Whether you’re a home student (living in Wales, Scotland or Northern Ireland), an EU student or a student from outside the EU, you may still be eligible for funding to train to teach.
+
+If you live in [Wales](http://www.studentfinancewales.co.uk/), [Scotland](http://www.saas.gov.uk/) or [Northern Ireland](http://www.studentfinanceni.co.uk/) you’ll need to contact your country’s student finance body.
+
+Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or [Isle of Man](https://www.gov.im/student-grants).
+
+You could get a bursary or scholarship, student finance and extra funding to train to teach.
+
+If you’re an EU national starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance.

--- a/content/funding-your-training/_bursaries-and-scholarships-cta.html.erb
+++ b/content/funding-your-training/_bursaries-and-scholarships-cta.html.erb
@@ -1,0 +1,6 @@
+<%= render CallsToAction::SimpleComponent.new(
+  icon: "arrow-icon",
+  text: "Find out how much is awarded for training to teach certain subjects through bursaries and scholarships.",
+  link_text: "Financial support for teacher training",
+  link_target: "https://beta-getintoteaching.education.gov.uk/guidance/financial-support-for-teacher-training",
+) %>

--- a/content/funding-your-training/_bursaries-and-scholarships.md
+++ b/content/funding-your-training/_bursaries-and-scholarships.md
@@ -1,0 +1,11 @@
+## Bursaries and scholarships
+
+Bursaries and scholarships are tax-free amounts of money to train in certain subjects. You don’t need to pay them back.
+
+You’ll need a first, 2:1, 2:2 degree or a PhD or Master's to be eligible for a bursary.
+
+For a scholarship, each professional scholarship body sets its own criteria.
+
+You could get a bursary of up to £24,000 or apply for a scholarship of up to £26,000.
+
+[Find out more about bursaries and scholarships](/guidance/financial-support-for-teacher-training#introduction).

--- a/content/funding-your-training/_bursaries-and-scholarships.md
+++ b/content/funding-your-training/_bursaries-and-scholarships.md
@@ -7,5 +7,3 @@ You’ll need a first, 2:1, 2:2 degree or a PhD or Master's to be eligible for a
 For a scholarship, each professional scholarship body sets its own criteria.
 
 You could get a bursary of up to £24,000 or apply for a scholarship of up to £26,000.
-
-[Find out more about bursaries and scholarships](/guidance/financial-support-for-teacher-training#introduction).

--- a/content/funding-your-training/_get-extra-financial-support-cta.html.erb
+++ b/content/funding-your-training/_get-extra-financial-support-cta.html.erb
@@ -1,0 +1,6 @@
+<%= render CallsToAction::SimpleComponent.new(
+  icon: "arrow-icon",
+  text: "Find out how much is awarded for training to teach certain subjects through bursaries and scholarships.",
+  link_text: "Financial support for teacher training",
+  link_target: "https://beta-getintoteaching.education.gov.uk/guidance/financial-support-for-teacher-training",
+) %>

--- a/content/funding-your-training/_get-extra-financial-support.md
+++ b/content/funding-your-training/_get-extra-financial-support.md
@@ -1,0 +1,10 @@
+## Extra financial support for parents, carers or people with disabilities
+
+You may be able to get extra financial support if you have a disability, or if you have children or dependent adults. If you get this type of funding, you do not need to pay it back.
+
+You could apply for:
+
+* [Disabled Students’ Allowance (DSA)](https://www.gov.uk/disabled-students-allowances-dsas/how-to-claim)
+* [Childcare Grant](https://www.gov.uk/childcare-grant)
+* [Parents Learning Allowance](https://www.gov.uk/parents-learning-allowance)
+* [Adult Dependants’ Grant](https://www.gov.uk/adult-dependants-grant)

--- a/content/funding-your-training/_tuition-fee-and-maintenance-loans-cta.html.erb
+++ b/content/funding-your-training/_tuition-fee-and-maintenance-loans-cta.html.erb
@@ -1,0 +1,6 @@
+<%= render CallsToAction::SimpleComponent.new(
+  icon: "arrow-icon",
+  text: "Use the student finance calculator on GOV.UK to find out how much you can get.",
+  link_text: "Student finance calculator",
+  link_target: "https://www.gov.uk/student-finance-calculator",
+) %>

--- a/content/funding-your-training/_tuition-fee-and-maintenance-loans.md
+++ b/content/funding-your-training/_tuition-fee-and-maintenance-loans.md
@@ -1,0 +1,9 @@
+## Tuition fee and maintenance loans
+
+You can apply for a tuition fee loan to pay for your training so you don't need to pay anything upfront. You can also apply for a maintenance loan to help with living costs and you may be able to get a [bursary or a scholarship](#bursaries-and-scholarships).
+
+Even if a bursary or scholarship is available for your course, you can get student finance to cover your fees and help with your living costs. You can apply for a tuition fee and/or a maintenance loan even if you already have a student loan.
+
+You can apply for a tuition fee loan of up to £9,250 to cover the full cost of your course fees and a maintenance loan of up to £12,010 to help with your living costs.
+
+You will only have to make repayments when you're earning. Your repayments will not increase if you already have a student loan and take a loan out for teacher training.


### PR DESCRIPTION
### Trello card

### Context

The funding page needed some CTAs between paragraphs and sections.

### Changes proposed in this pull request

Split the funding page into partials and place CTA's between them where necessary. This is done via the list of partials in the frontmatter.

### Guidance to review

![funding-your-training](https://user-images.githubusercontent.com/128088/102369812-46d59e00-3fb4-11eb-9d57-39ced945d3bd.png)


