### PR TITLE
Replace more_stories panel with explore panel

### DIFF
--- a/content/my-story-into-teaching/career-changers/becoming-a-mum-sparked-my-interest-in-teaching.md
+++ b/content/my-story-into-teaching/career-changers/becoming-a-mum-sparked-my-interest-in-teaching.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Clair Johnson
   position: Physics teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/financiers-future-in-maths.md
+++ b/content/my-story-into-teaching/career-changers/financiers-future-in-maths.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Peter Bassett
   position: Maths teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/from-construction-site-to-classroom.md
+++ b/content/my-story-into-teaching/career-changers/from-construction-site-to-classroom.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Julia Capon
   position: Career changer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/from-developing-software-to-developing-students.md
+++ b/content/my-story-into-teaching/career-changers/from-developing-software-to-developing-students.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Steven Li
   position: Deputy director of learning for ICT and maths
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/leaping-to-head-of-department.md
+++ b/content/my-story-into-teaching/career-changers/leaping-to-head-of-department.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Jon Simmons
   position: Head of department
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/make-a-difference-to-young-people.md
+++ b/content/my-story-into-teaching/career-changers/make-a-difference-to-young-people.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Sarah Birt
   position: Career changer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/natural-transition-from-engineering-to-teaching-physics.md
+++ b/content/my-story-into-teaching/career-changers/natural-transition-from-engineering-to-teaching-physics.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Roger Brown
   position: Career changer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/passing-on-my-knowledge.md
+++ b/content/my-story-into-teaching/career-changers/passing-on-my-knowledge.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Amy Salwey
   position: career changer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/police-officer-to-pe-teacher.md
+++ b/content/my-story-into-teaching/career-changers/police-officer-to-pe-teacher.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Victoria Barton
   position: Former police officer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/royal-marine-commando-to-geography-teacher.md
+++ b/content/my-story-into-teaching/career-changers/royal-marine-commando-to-geography-teacher.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Thomas
   position: Trainee geography teacher and former Royal Marine Commando
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch.md
+++ b/content/my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Zainab Kasmani
   position: Trainee primary school teacher
-more_stories:
-  - name: Shaun
-    snippet: Returning to teaching with support from an adviser
-    image: /assets/images/stories/stories-shaun.jpg
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
-  - name: Victoria
-    snippet: Police officer to PE teacher
-    image: /assets/images/stories/stories-victoria.jpg
-    link: /my-story-into-teaching/career-changers/police-officer-to-pe-teacher
-  - name: Tarik
-    snippet: Getting our 'geek' on:kids coding
-    image: /assets/images/stories/stories-tarik.jpg
-    link: /my-story-into-teaching/making-a-difference/getting-our-geek-on-kids-coding
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/swapping-senior-management-for-students.md
+++ b/content/my-story-into-teaching/career-changers/swapping-senior-management-for-students.md
@@ -8,19 +8,10 @@ story:
   teacher: Karen Roberts
   video: https://www.youtube.com/embed/riY-1DUkLVk
   position: languages teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/teaching-gave-me-purpose.md
+++ b/content/my-story-into-teaching/career-changers/teaching-gave-me-purpose.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Luke Anderson
   position: Masters in languages
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching.md
+++ b/content/my-story-into-teaching/career-changers/transferring-my-skills-to-teaching.md
@@ -7,19 +7,10 @@ backlink_text: Career changers' stories
 story:
   teacher: Will Fordham
   position: Trainee English teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/grasp-every-opportunity.md
+++ b/content/my-story-into-teaching/career-progression/grasp-every-opportunity.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Paul Evason
   position: Assistant headteacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher.md
+++ b/content/my-story-into-teaching/career-progression/lawyer-to-assistant-teacher.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Helen Winter
   position: Director of teaching school and assistant headteacher
-more_stories:
-  - name: Shaun
-    snippet: Return to teaching with support from an adviser
-    image: /assets/images/stories/stories-shaun.jpg
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
-  - name: Victoria
-    snippet: Police officer to PE teacher
-    image: /assets/images/stories/stories-victoria.jpg
-    link: /my-story-into-teaching/career-changers/police-officer-to-pe-teacher
-  - name: Tarik
-    snippet: "Getting our 'geek' on: kids coding"
-    image: /assets/images/stories/stories-tarik.jpg
-    link: /my-story-into-teaching/making-a-difference/getting-our-geek-on-kids-coding
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/leaping-to-head-of-department.md
+++ b/content/my-story-into-teaching/career-progression/leaping-to-head-of-department.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Jon Simmons
   position: Head of department
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/newly-qualified-to-head-of-faculty.md
+++ b/content/my-story-into-teaching/career-progression/newly-qualified-to-head-of-faculty.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Karen Falcon
   position: Head of department for geography
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/nqt-to-head-of-biology.md
+++ b/content/my-story-into-teaching/career-progression/nqt-to-head-of-biology.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Sarah Fisher
   position: Head of biology
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/career-progression/one-year-from-post-grad-to-hod.md
+++ b/content/my-story-into-teaching/career-progression/one-year-from-post-grad-to-hod.md
@@ -7,19 +7,10 @@ backlink_text: Career progression stories
 story:
   teacher: Dr Owen Mather
   position: Leader of teaching standards
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience.md
+++ b/content/my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience.md
@@ -7,19 +7,10 @@ backlink_text: Stories from international teachers
 story:
   teacher: Katie Lockett
   position: Head of Faculty
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 more_information:
   link: /international-candidates
   text: International candidates information

--- a/content/my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser.md
+++ b/content/my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser.md
@@ -7,19 +7,10 @@ backlink_text: Stories from international teachers
 story:
   teacher: Shaun
   position: returning teacher
-more_stories:
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Claire
-    snippet: Becoming a mum sparked my interest
-    image: /assets/images/stories/stories-claire.jpg
-    link: /my-story-into-teaching/career-changers/becoming-a-mum-sparked-my-interest-in-teaching
-  - name: Sarah
-    snippet: NQT to Head of Biology
-    image: /assets/images/stories/stories-sarah-f.jpg
-    link: /my-story-into-teaching/career-progression/nqt-to-head-of-biology
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 more_information:
   link: /international-candidates
   text: International candidates information

--- a/content/my-story-into-teaching/making-a-difference/broadening-horizons-through-travelling-and-teaching.md
+++ b/content/my-story-into-teaching/making-a-difference/broadening-horizons-through-travelling-and-teaching.md
@@ -7,19 +7,10 @@ backlink_text: Stories about making a difference
 story:
   teacher: Craig Cairns
   position: Primary teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/making-a-difference/getting-our-geek-on-kids-coding.md
+++ b/content/my-story-into-teaching/making-a-difference/getting-our-geek-on-kids-coding.md
@@ -7,19 +7,10 @@ backlink_text: Stories about making a difference
 story:
   teacher: Tarik Reghif
   position: career changer
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/making-a-difference/going-back-and-giving-back.md
+++ b/content/my-story-into-teaching/making-a-difference/going-back-and-giving-back.md
@@ -7,19 +7,10 @@ backlink_text: Stories about making a difference
 story:
   teacher: Sandra Macfarlane
   position: Head of RE
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/making-a-difference/inspiring-our-young-entrepreneurs.md
+++ b/content/my-story-into-teaching/making-a-difference/inspiring-our-young-entrepreneurs.md
@@ -7,19 +7,10 @@ backlink_text: Stories about making a difference
 story:
   teacher: Laura Hurn
   position:
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/making-a-difference/no-two-days-are-the-same.md
+++ b/content/my-story-into-teaching/making-a-difference/no-two-days-are-the-same.md
@@ -4,22 +4,14 @@ title: No two days are the same
 image: /assets/images/stories/stories-gavin.jpg
 backlink: "./"
 backlink_text: Stories about making a difference
+featured_story_card: yes
 story:
   teacher: Gavin McIntyre
   position: assistant headteacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success.md
+++ b/content/my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success.md
@@ -7,19 +7,10 @@ backlink_text: Stories about making a difference
 story:
   teacher: Danny Holliday
   position: physical education (PE) teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/returners/getting-back-into-the-classroom.md
+++ b/content/my-story-into-teaching/returners/getting-back-into-the-classroom.md
@@ -7,19 +7,10 @@ backlink_text: Stories about returning to teaching
 story:
   teacher: Jill
   position: Returning teacher
-more_stories:
-  - name: Shaun
-    snippet: Returning to teaching with support from an adviser
-    image: /assets/images/stories/stories-shaun.jpg
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
-  - name: Karen
-    snippet: Swapping senior management for students
-    image: /assets/images/stories/stories-karen.jpg
-    link: /my-story-into-teaching/career-changers/swapping-senior-management-for-students
-  - name: Craig
-    snippet: Broadening horizons through travelling and teaching
-    image: /assets/images/stories/stories-craig.jpg
-    link: /my-story-into-teaching/making-a-difference/broadening-horizons-through-travelling-and-teaching
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 more_information:
   link: /returning-to-teaching
   text: Read further guidance if you're returning to teaching

--- a/content/my-story-into-teaching/returners/top-tips-for-returning-teachers.md
+++ b/content/my-story-into-teaching/returners/top-tips-for-returning-teachers.md
@@ -7,19 +7,10 @@ backlink_text: Stories about returning to teaching
 story:
   teacher: Helen
   position: Returning teacher
-more_stories:
-  - name: Shaun
-    snippet: Returning to teaching with support from an adviser
-    image: /assets/images/stories/stories-shaun.jpg
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
-  - name: Karen
-    snippet: Swapping senior management for students
-    image: /assets/images/stories/stories-karen.jpg
-    link: /my-story-into-teaching/career-changers/swapping-senior-management-for-students
-  - name: Craig
-    snippet: Broadening horizons through travelling and teaching
-    image: /assets/images/stories/stories-craig.jpg
-    link: /my-story-into-teaching/making-a-difference/broadening-horizons-through-travelling-and-teaching
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 more_information:
   link: /returning-to-teaching
   text: Read further guidance if you're returning to teaching

--- a/content/my-story-into-teaching/teacher-training-stories/banker-turned-teacher.md
+++ b/content/my-story-into-teaching/teacher-training-stories/banker-turned-teacher.md
@@ -7,19 +7,10 @@ backlink_text: Teacher training stories
 story:
   teacher: Katherine Hills
   position: Modern foreign languages
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning.md
+++ b/content/my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning.md
@@ -7,19 +7,10 @@ backlink_text: Teacher training stories
 story:
   teacher: Nathan Sproule
   position: Salaried teacher trainee
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it.md
+++ b/content/my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it.md
@@ -7,19 +7,10 @@ backlink_text: Teacher training stories
 story:
   teacher: Hasina Nizamee
   position: Teacher in training
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 

--- a/content/my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss.md
+++ b/content/my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss.md
@@ -7,19 +7,10 @@ backlink_text: Teacher training stories
 story:
   teacher: Emma Maskell
   position: Technician turned science teacher
-more_stories:
-  - name: Zainab
-    snippet: School experience helped me decide to switch
-    image: /assets/images/stories/stories-zainab.jpg
-    link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
-  - name: Katie
-    snippet: Returning to teach with international experience
-    image: /assets/images/stories/stories-katie.png
-    link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
-  - name: Helen
-    snippet: Lawyer to assistant headteacher
-    image: /assets/images/stories/stories-helen.jpg
-    link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
+explore:
+  - card_type: find events
+  - card_type: featured story
+  - card_type: chat online
 build_layout_from_frontmatter: true
 ---
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/xmUzKlT8

### Context

The more stories panel should be replaced with the "Explore Get into Teaching" panel

### Changes proposed in this pull request

1. Updated the various stories featuring the 'more_stories' panel
2. Nominated a 'featured' story

