### PR TITLE
Increase Timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   turnstyle:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Check workflow concurrency
         uses: softprops/turnstyle@v1


### PR DESCRIPTION
The test phase can take 20 minutes, if a second job starts soon after a first it can time out waiting.

Increase turnstyle timeout to 30 minutes. which should be plenty of time for a job to finish

