### PR TITLE
Copy OWASP Scan from TTA and Re-initiate in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,13 @@ jobs:
         if: steps.wait-for-deploy.outputs.conclusion == 'failure'
         run: exit 1
 
+      - name: Trigger OWASP Testing
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+          workflow: owasp
+          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          inputs: '{"environment": "dev"}'
+
       - name: Generate Tag from PR Number
         id: tag_version
         uses: DFE-Digital/github-actions/GenerateReleaseFromSHA@master

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -1,0 +1,36 @@
+name: owasp
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment to test to eg: dev/test/prod etc'
+        required: true
+
+jobs:
+  owasp:
+    name: 'OWASP Test ${{ github.event.inputs.environment }}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          docker_name: 'owasp/zap2docker-stable'
+          target: 'https://${{ secrets.HTTPAUTH_USERNAME }}:${{ secrets.HTTPAUTH_PASSWORD }}@${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
+          rules_file_name: '.zap/rules.tsv'
+          cmd_options: '-a'
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: ${{env.SLACK_FAILURE}}
+           SLACK_MESSAGE: 'Pipeline Failure carrying out OWASP Testing on https://${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
+           SLACK_TITLE: 'Failure: OWSAP Testing has failed on ${{ github.event.inputs.environment }}'
+           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### [OWASP Scan has been lost from content deployment.](https://trello.com/c/Oy2ulhII/691-owasp-scan-has-been-lost-from-content-deployment)

### Context
At some point the OWASP testing was removed from the content deployment. to maintain security standards it now is triggered when deployed to development. but it does not stop the deployment and just alerts on slack about any errors

### Review Advise
This change does not impact the application, but of course will re-deliver the current master
If the OWASP Fails an alert will be triggered on SLACK but it will NOT stop the deployment.