### PR TITLE
Make some guidance content tweaks

### DIFF
--- a/content/guidance/become-a-teacher-in-england.md
+++ b/content/guidance/become-a-teacher-in-england.md
@@ -9,13 +9,6 @@ related_content:
   "Qualified teacher status (QTS): qualify to teach in England": https://www.gov.uk/guidance/qualified-teacher-status-qts
 ---
 
-## Contents
-
-* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
-{:toc}
-
-## Introduction
-
 This page explains what you’ll need to become a teacher in England.
 
 The routes to teacher training in other parts of the UK are different –
@@ -23,6 +16,11 @@ learn more about teacher training in [Northern
 Ireland](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland),
 [Scotland](https://teachinscotland.scot/) and
 [Wales](https://www.discoverteaching.wales/routes-into-teaching/).
+
+### Contents
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 ## Learn more about life as a teacher
 

--- a/content/guidance/financial-support-for-teacher-training.md
+++ b/content/guidance/financial-support-for-teacher-training.md
@@ -18,6 +18,4 @@ content:
   - content/guidance/financial-support-for-teacher-training/tuition-fees-and-maintenance-loans
   - content/guidance/financial-support-for-teacher-training/parents-and-carers
   - content/guidance/financial-support-for-teacher-training/disabled-students
-  - content/guidance/financial-support-for-teacher-training/find-an-event
-  - content/guidance/financial-support-for-teacher-training/contact-and-support
 ---

--- a/content/guidance/financial-support-for-teacher-training/_contact-and-support.html.erb
+++ b/content/guidance/financial-support-for-teacher-training/_contact-and-support.html.erb
@@ -1,3 +1,0 @@
-<h2>Contact and support</h2>
-
-<%= render CallsToAction::ChatOnlineComponent.new %>

--- a/content/guidance/financial-support-for-teacher-training/_contents.md
+++ b/content/guidance/financial-support-for-teacher-training/_contents.md
@@ -1,4 +1,0 @@
-## Contents
-
-* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
-{:toc}

--- a/content/guidance/financial-support-for-teacher-training/_find-an-event.md
+++ b/content/guidance/financial-support-for-teacher-training/_find-an-event.md
@@ -1,5 +1,0 @@
-## Find a Train To Teach event near you
-
-[Get Into Teaching’s nationwide events](/events) are informal
-opportunities for you to get free expert advice about your next steps
-into teaching.

--- a/content/guidance/financial-support-for-teacher-training/_intro.md
+++ b/content/guidance/financial-support-for-teacher-training/_intro.md
@@ -1,5 +1,3 @@
-## Introduction
-
 The level of financial support you get will depend on the subject you
 choose and the way you train to become a teacher.
 


### PR DESCRIPTION
Make some minor content tweaks based on feedback from @CroftLA

The final sections of the financial support guidance page were deemed unnecessary and removed now the page is in a GiT-style (the links are visible from the nav, footer and talk to us section)

Improve the placement of the table of contents in 'Becoming a teacher in England' it's now placed after the intro paragraph.