### PR TITLE
Remove comma from end of teacher's name

### DIFF
--- a/content/my-story-into-teaching/career-changers/passing-on-my-knowledge.md
+++ b/content/my-story-into-teaching/career-changers/passing-on-my-knowledge.md
@@ -4,7 +4,7 @@ image: /assets/images/stories/stories-amy.jpg
 backlink: "./"
 backlink_text: Career changers' stories
 story:
-  teacher: Amy Salwey,
+  teacher: Amy Salwey
   position: career changer
 more_stories:
   - name: Zainab


### PR DESCRIPTION
The comma is already provided by the template and it being here results in there being two:

![Screenshot from 2021-01-13 09-07-15](https://user-images.githubusercontent.com/128088/104430577-c5573880-557e-11eb-81d2-6a1b2a407dfd.png)



