### PR TITLE
Remove reference to GOV.UK

### DIFF
--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -73,7 +73,7 @@
         name: simple
         arguments:
           title: Become a teacher
-          text: Read more detailed guidance on GOV.UK on how to become a teacher in England.
+          text: Read more detailed guidance on how to become a teacher in England.
           link_text: Find out more
           link_target: /guidance/become-a-teacher-in-england
           icon: icon-arrow


### PR DESCRIPTION


### Trello card

https://trello.com/c/y4iqFH0i/723-remove-reference-to-on-govuk-in-the-become-a-teacher-box-on-ways-to-train-page

### Context

The guidance pages are now GiT-styled so the descriptive text doesn't really make sense any more.

### Changes proposed in this pull request

Remove 'GOV.UK' from CTA text
