### PR TITLE
Add descriptions for photo alt attributes

### DIFF
--- a/content/my-story-into-teaching/career-changers.md
+++ b/content/my-story-into-teaching/career-changers.md
@@ -8,59 +8,73 @@ stories:
   - name: Claire
     snippet: Becoming a mum sparked my interest in teaching
     image: /assets/images/stories/stories-claire.jpg
+    image_description: Photograph of Clair Johnson, physics teacher
     link: /my-story-into-teaching/career-changers/becoming-a-mum-sparked-my-interest-in-teaching
   - name: Peter
     snippet: Financier's future in maths
     image: /assets/images/stories/stories-peter.jpg
+    image_description: Photograph of Perer Bassett, maths teacher
     link: /my-story-into-teaching/career-changers/financiers-future-in-maths
   - name: Julia
     snippet: From construction site to classroom
     image: /assets/images/stories/stories-julia.jpg
+    image_description: Photograph of Julia Capon, career changer
     link: /my-story-into-teaching/career-changers/from-construction-site-to-classroom
   - name: Steven
     snippet: From developing software to developing students
     image: /assets/images/stories/stories-steven.jpg
+    image_description: Photograph of Steven Li, deputy director of learning for ICT and maths
     link: /my-story-into-teaching/career-changers/from-developing-software-to-developing-students
   - name: Jon
     snippet: Swapping senior management for students
     image: /assets/images/stories/stories-jon.jpg
+    image_description: Photograph of head of department, Jon Simmons
     link: /my-story-into-teaching/career-changers/leaping-to-head-of-department
   - name: Sarah
     snippet: Make a difference to young people
     image: /assets/images/stories/stories-sarah.jpg
+    image_description: Photograph of Sarah Birt, career changer
     link: /my-story-into-teaching/career-changers/make-a-difference-to-young-people
   - name: Roger
     snippet: Natural transition from engineering to teaching physics
     image: /assets/images/stories/stories-roger.jpg
+    image_description: Photograph of Roger Brown, career changer
     link: /my-story-into-teaching/career-changers/natural-transition-from-engineering-to-teaching-physics
   - name: Amy
     snippet: Passing on my knowledge
     image: /assets/images/stories/stories-amy.jpg
+    image_description: Photograph of Amy Salwey, career changer
     link: /my-story-into-teaching/career-changers/passing-on-my-knowledge
   - name: Victoria
     snippet: Police officer to PE teacher (primary)
     image: /assets/images/stories/stories-victoria.jpg
     link: /my-story-into-teaching/career-changers/police-officer-to-pe-teacher
+    image_description: Photograph of primary school PE teacher, Victoria Barton
   - name: Thomas
     snippet: Royal Marine Commando to geography teacher
     image: /assets/images/stories/stories-thomas.jpg
+    image_description: Photograph of trainee geography teacher, Thomas
     link: /my-story-into-teaching/career-changers/royal-marine-commando-to-geography-teacher
   - name: Zainab
     snippet: School experience helped me decide to switch
     image: /assets/images/stories/stories-zainab.jpg
+    image_description: Photograph of trainee primary teacher Zainab Kasmani
     link: /my-story-into-teaching/career-changers/school-experience-helped-me-decide-to-switch
   - name: Karen
     snippet: Swapping senior management for students
     video: https://www.youtube.com/watch?v=riY-1DUkLVk
     image: /assets/images/stories-karen.jpg
+    image_description: Photograph of languages teacher Karen Roberts
     link: /my-story-into-teaching/career-changers/swapping-senior-management-for-students
   - name: Luke
     snippet: Teaching gave me purpose
     image: /assets/images/stories/stories-luke.jpg
+    image_description: Photograph of languages teacher Luke Anderson
     link: /my-story-into-teaching/career-changers/teaching-gave-me-purpose
   - name: Will
     snippet: Transferring my skills to teaching
     image: /assets/images/stories/stories-will.jpg
+    image_description: Photograph of trainee English teacher, Will Fordham
     link: /my-story-into-teaching/career-changers/transferring-my-skills-to-teaching
 ---
 

--- a/content/my-story-into-teaching/career-progression.md
+++ b/content/my-story-into-teaching/career-progression.md
@@ -8,26 +8,32 @@ stories:
   - name: Paul
     snippet: "Grasp every opportunity: you will progress"
     image: /assets/images/stories/stories-paul.jpg
+    image_description: Photograph of Paul Evason, assistant headteacher
     link: /my-story-into-teaching/career-progression/grasp-every-opportunity
   - name: Helen
     snippet: Lawyer to assistant headteacher
     image: /assets/images/stories/stories-helen.jpg
+    image_description: Photograph of assistant headteacher and director, Helen Winter
     link: /my-story-into-teaching/career-progression/lawyer-to-assistant-teacher
   - name: Jon
     snippet: Leaping to head of department
     image: /assets/images/stories/stories-jon.jpg
+    image_description: Photograph of department head, Jon Simmons
     link: /my-story-into-teaching/career-progression/leaping-to-head-of-department
   - name: Karen
     snippet: From newly qualified teacher to head of faculty in 5 years
     image: /assets/images/stories/stories-karen-f.jpg
+    image_description: Photograph of head of geography, Karen Falcon
     link: /my-story-into-teaching/career-progression/newly-qualified-to-head-of-faculty
   - name: Sarah
     snippet: NQT to head of biology in 2 years
     image: /assets/images/stories/stories-sarah-f.jpg
+    image_description: Photograph of head of biology, Sarah Fisher
     link: /my-story-into-teaching/career-progression/nqt-to-head-of-biology
   - name: Owen
     snippet: One year from post grad to head of department
     image: /assets/images/stories/stories-owen.jpg
+    image_description: Photograph of leader of teaching standards, Dr Owen Mather
     link: /my-story-into-teaching/career-progression/one-year-from-post-grad-to-hod
 ---
 

--- a/content/my-story-into-teaching/international-career-changers.md
+++ b/content/my-story-into-teaching/international-career-changers.md
@@ -8,10 +8,12 @@ stories:
   - name: Katie
     snippet: Returning to teaching with international experience
     image: /assets/images/stories/stories-katie.png
+    image_description: Photograph of Faculty Head, Katie Lockett
     link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-international-experience
   - name: Shaun
     snippet: Returning to teaching with support from an adviser
     image: /assets/images/stories/stories-shaun.jpg
+    image_description: Photograph of international returning teacher, Shaun
     link: /my-story-into-teaching/international-career-changers/returning-to-teaching-with-support-from-an-adviser
 
 ---

--- a/content/my-story-into-teaching/making-a-difference.md
+++ b/content/my-story-into-teaching/making-a-difference.md
@@ -9,26 +9,31 @@ stories:
     snippet: Broadening horizons through travelling and teaching
     link: /my-story-into-teaching/making-a-difference/broadening-horizons-through-travelling-and-teaching
     image: /assets/images/stories/stories-craig.jpg
+    image_description: A photograph of Craig Cairns, Primary Teacher
   - name: Tarik
     snippet: "Getting our 'geek' on: kids coding"
     image: /assets/images/stories/stories-tarik.jpg
+    image_description: A photograph of Tarik Reghif, a career changer
     link: /my-story-into-teaching/making-a-difference/getting-our-geek-on-kids-coding
   - name: Sandra
     snippet: Going back and giving back
     image: /assets/images/stories/stories-sandra.jpg
+    image_description: A photograph of Sandra Macfarlane, Head of RE
     link: /my-story-into-teaching/making-a-difference/going-back-and-giving-back
   - name: Laura
     snippet: Broadening horizons through travelling and teaching
     image: /assets/images/stories/stories-laura.jpg
+    image_description: A photograph of teacher, Laura Hurn
     link: /my-story-into-teaching/making-a-difference/inspiring-our-young-entrepreneurs
   - name: Gavin
     snippet: No two days are the same
     image: /assets/images/stories/stories-gavin.jpg
+    image_description: A photograph of Gavin McIntyre, Assistant Headteacher
     link: /my-story-into-teaching/making-a-difference/no-two-days-are-the-same
-
   - name: Danny
     snippet: Turning a tough lesson into a success
     image: /assets/images/stories/stories-danny.jpg
+    image_description: A photograph of Danny Holliday, PE teacher
     link: /my-story-into-teaching/making-a-difference/turning-a-tough-lesson-into-success
 ---
 

--- a/content/my-story-into-teaching/returners.md
+++ b/content/my-story-into-teaching/returners.md
@@ -9,10 +9,12 @@ stories:
     snippet: Getting back into the classroom
     link: /my-story-into-teaching/returners/getting-back-into-the-classroom
     image: /assets/images/stories/stories-jill.jpg
+    image_description: Photograph of returning teacher, Jill
   - name: Helen
     snippet: Top tips for returning to teaching
     link: /my-story-into-teaching/returners/top-tips-for-returning-teachers
     image: /assets/images/stories/stories-helen.jpg
+    image_description: Photograph of returning teacher, Helen
 ---
 
 Read stories from former teachers who have returned to the profession.

--- a/content/my-story-into-teaching/teacher-training-stories.md
+++ b/content/my-story-into-teaching/teacher-training-stories.md
@@ -8,18 +8,22 @@ stories:
   - name: Katherine
     snippet: Banker turned teacher
     image: /assets/images/stories/stories-katherine.jpg
+    image_description: Photograph of modern foreign languages teacher Katherine Hills
     link: /my-story-into-teaching/teacher-training-stories/banker-turned-teacher
   - name: Nathan
     snippet: "Salaried teacher training: classroom learning"
     image: /assets/images/stories/stories-nathan.jpg
+    image_description: Photograph of trainee teacher, Nathan Sproule
     link: /my-story-into-teaching/teacher-training-stories/salaried-teacher-training-classroom-learning
   - name: Hasina
     snippet: "Teacher training: it’s worth it"
     image: /assets/images/stories/stories-generic.jpg
+    image_description: Photograph of trainee teacher, Hasina Nizamee
     link: /my-story-into-teaching/teacher-training-stories/teacher-training-its-worth-it
   - name: Emma
     snippet: Why don't you teach, miss?
     image: /assets/images/stories/stories-emma.jpg
+    image_description: Photograph of Science Teacher, Emma Maskell
     link: /my-story-into-teaching/teacher-training-stories/why-dont-you-teach-miss
 
 ---


### PR DESCRIPTION
Add `image_description` to story index pages front matter for thumbnail alt attributes.