### PR TITLE
Added assessment only providers

### DIFF
--- a/content/_assessment-only-providers-listing.html.erb
+++ b/content/_assessment-only-providers-listing.html.erb
@@ -1,0 +1,3 @@
+<h2>Select the region of the provider</h2>
+
+<%= render GroupedCards::ListingComponent.new @front_matter["providers"] %>

--- a/content/assessment-only-providers.md
+++ b/content/assessment-only-providers.md
@@ -1,0 +1,459 @@
+---
+title: Providers of the Assessment Only (AO) route to QTS
+image: false
+backlink: /
+fullwidth: true
+content:
+  - content/assessment-only-providers-listing
+providers:
+  East of England:
+  - header: Billericay Educational Consortium
+    link: http://secondary.billericayscitt.com/assessment-only-route-2/
+    name: Fiona Manby
+    telephone: 01245 683619
+    email: info@billericayscitt.com
+  - header: Chiltern Training Group SCITT
+    link: http://www.challneyboys.co.uk/
+    name: Karen Bateman
+    telephone: '01582 599921'
+    email: kbateman@challneyboys.luton.sch.uk
+  - header: Essex and Thames Primary SCITT
+    link: https://etpscitt.co.uk/
+    name: Fan Attwood
+    telephone: '01268 570215'
+    email: Fran@etpscitt.co.uk
+  - header: Essex Teacher Training
+    link: http://www.essexteachertraining.co.uk
+    name: Kay Satchell
+    email: kay.satchell@essexteachertraining.co.uk
+  - header: Mid Essex Initial Teacher Training
+    link: http://midessexteachertraining.com/
+    name: Keith Ferguson
+    telephone: 01376 556398
+    email: ao@midessexteachertraining.com
+  - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
+    link: http://www.essexprimaryscitt.co.uk/
+    name: Fiona Willett
+    telephone: '0738885808'
+    email: fiona@essexprimaryscitt.co.uk
+  - header: Norfolk Teacher Training Centre
+    link: https://www.norfolkttc.org.uk/
+    name: Jacqui Waring
+    telephone: 01603 773708
+    email: jacqui.waring@ccn.ac.uk
+  - header: SAF ITT
+    name: Su Bernard
+    telephone: 01234 827145
+    email: SBernard@saf.org.uk
+  - header: Suffolk and Norfolk ITT
+    link: http://www.snitt.co.uk/
+    name: Lucinda James
+    telephone: 01473 265077
+    email: enquiries@suffolkandnorfolkscitt.co.uk
+  - header: The Bedfordshire Schools Training Partnership
+    link: http://www.bedsscitt.org.uk/
+    name: David Goode
+    telephone: 01462 817445
+    email: office@bedsscitt.org.uk
+  - header: The Cambridge Partnership
+    link: http://www.thecambridgepartnership.co.uk/
+    name: Claire Mott
+    telephone: '01487 833707'
+    email: cmott@campartnership.org
+  - header: The Shire Foundation
+    name: Julie Darmody
+    telephone: '01582 522121'
+    email: jdarmody@shirefoundation.co.uk
+  - header: University of Bedfordshire
+    link: http://www.beds.ac.uk/
+    name: Bedford Admissions
+    telephone: 01234 793279
+    email: admission@beds.ac.uk
+  - header: University of Hertfordshire
+    link: http://www.herts.ac.uk/apply/schools-of-study/education/initial-teacher-training/assessment-only-route
+    name: Lee Hague (AO Administrator)
+    telephone: 01707 285612
+    email: l.a.hague@herts.ac.uk
+  East Midlands:
+  - header: Bishop Grosseteste University
+    link: http://www.bishopg.ac.uk
+    name: Dr Abigail Parrish
+    telephone: 01522 583729
+    email: abigail.parrish@bishopg.ac.uk
+  - header: CfBT Education Trust SCITT
+    name: Julie Woolley
+    telephone: '07919 568841'
+    email: jwoolley@cfbt.com
+  - header: Educate Teacher Training
+    link: http://www.educateteachertraining.co.uk/
+    name: Claire King
+    telephone: 01476 512793
+    email: aor@educate-group.co.uk
+  - header: Nottingham Trent University
+    link: http://www.ntu.ac.uk/
+    name: Admissions team
+    telephone: 0115 848 4200
+    email: applications@ntu.ac.uk
+  - header: The Grand Union Training Partnership
+    link: http://www.gutp.co.uk/
+    name: Tracey Oakley
+    telephone: 01327 350284 ext. 251
+    email: gutp@sponne.org.uk
+  - header: University of Derby
+    link: http://www.derby.ac.uk/
+    name: Aneesa Akhtar
+    email: AO@derby.ac.uk
+  Greater London:
+  - header: 2Schools Consortium
+    link: http://www.2schools.org/assessment-only-route/
+    name: Isabella Mora
+    telephone: '0208 807 6906'
+    email: training@oakthorpe.enfield.sch.uk
+  - header: Bromley Schools’ Collegiate
+    link: http://www.bscteach.co.uk/
+    name: Derek Boyle
+    telephone: 020 8300 6566
+    email: Administrator@gradteach.co.uk
+  - header: Goldsmiths, University of London
+    link: http://www.gold.ac.uk/
+    name: Lynsey Salt
+    telephone: 020 7717 2245
+    email: ao@gold.ac.uk
+  - header: Henry Maynard Training E17
+    link: https://www.henrymaynardtraining.co.uk
+    name: Clare Hunton
+    telephone: '0208 5203142'
+    email: training@henrymaynard.waltham.sch.uk
+  - header: Jewish Teacher Training Partnership
+    link: http://www.lsjs.ac.uk/
+    name: Galia Segal
+    telephone: 020 8203 6427
+    email: galia.segal@lsjs.ac.uk
+  - header: Kingston University
+    link: http://www.kingston.ac.uk/postgraduate-course/assessment-only-route-leading-to-qualified-teacher-status/
+    name: Marcus Bhargava
+    telephone: 020 8417 4766
+    email: aoenquiries@kingston.ac.uk
+  - header: London Metropolitan University
+    link: https://www.londonmet.ac.uk/courses/postgraduate/assessment-only-ao-route-to-qualified-teacher-status---qts---qts/
+    name: Maria Dominguez
+    telephone: 0207 133 2983
+    email: m.dominguez@londonmet.ac.uk
+  - header: London South Bank University
+    link: https://www.lsbu.ac.uk
+    name: Andrew Read
+    telephone: 0207 815 5444
+    email: qtsao@lsbu.ac.uk
+  - header: Middlesex University
+    telephone: 020 8411 5555
+    email: enquiries@mdx.ac.uk
+  - header: North Essex Teacher Training (NETT)
+    link: http://www.nett.org.uk/
+    telephone: '01255431949'
+    email: teach@nett.org.uk
+  - header: St Mary’s University
+    link: http://www.stmarys.ac.uk/education-theology-and-leadership/assessment-only-qts.htm
+    name: Elizabeth Jackson
+    telephone: '0208 2404326'
+    email: ao@stmarys.ac.uk
+  - header: 'Teaching London: LDBS SCITT'
+    link: http://teachinglondon.org
+    name: Saskia Rossi
+    telephone: 0207 932 1126
+    email: admin@teachinglondon.org
+  - header: The Havering Teacher Training Partnership
+    link: http://www.haveringteachertraining.co.uk/
+    name: Liz Connell
+    telephone: '01708 255006'
+    email: http@hallmeadschool.com
+  - header: The Pimlico-London SCITT
+    link: http://www.futuretraining.org/assessment-only/
+    email: info@futuretraining.org
+  - header: University of East London
+    link: http://www.uel.ac.uk/
+    name: Bryce Wilby
+    telephone: 020 8223 6372
+    email: b.wilby@uel.ac.uk
+  - header: University of Greenwich
+    name: Enquiry Unit
+    telephone: 020 8331 9000
+    email: courseinfo@gre.ac.uk
+  - header: Wandsworth Primary Schools’ Consortium
+    link: http://www.beatrixpotterschool.com/our-school/wandsworth-scitt-teacher-training/
+    name: Sam Steward
+    telephone: 020 8772 9528
+    email: ssteward@scitt.wandsworth.sch.uk
+  North East:
+  - header: Carmel Teacher Training Partnership (CTTP)
+    link: http://www.carmel.org.uk/
+    name: Marielle Thonnart
+    telephone: 01325 254525
+    email: thonnartm@carmel.bhcet.org.uk
+  - header: Durham University
+    email: ed.ite@durham.ac.uk
+  - header: Stockton-on-Tees Teacher Training Partnership
+    link: http://www.stocktonscitt.uk
+    name: Kirsten Webber
+    telephone: 01642 527675
+    email: scitt@stockton.gov.uk
+  - header: University of Sunderland
+    link: http://www.sunderland.ac.uk/
+    name: Jill Wilkinson
+    telephone: '0191 5153099'
+    email: jill.wilkinson@sunderland.ac.uk
+  North West:
+  - header: Ashton on Mersey SCITT
+    link: http://aomscitt.co.uk/assessment-only/
+    name: Samantha Buckley
+    telephone: 0161 973 1179 (ext 2229)
+    email: SamanthaBuckley@thedeantrust.co.uk
+  - header: Cumbria Teacher Training
+    link: http://www.ctt.ac.uk/
+    email: scittlead@ctt.ac.uk
+  - header: Kingsbridge EIP SCITT
+    name: Gail Thomson
+    telephone: '01942 510712 ext 500'
+    email: g.thomson@kingsbridgeeip.co.uk
+  - header: Mersey Boroughs ITT Partnership
+    name: Neil Dixon
+    telephone: 0151 426 6869
+    email: neil.dixon@knowsley.gov.uk
+  - header: Merseyside, Cheshire & Greater Manchester Teacher Training Consortium
+    link: https://www.teachertrainingconsortium.info
+    email: admin@teachertrainingconsortium.org.uk
+  - header: North Manchester ITT Partnership
+    link: https://www.teachnorthmanchester.com/assessment-only
+    name: Carrie Carvell
+    telephone: 0161 202 0161
+    email: teachertraining@mca.manchester.sch.uk
+  - header: Star Teachers SCITT
+    name: Felicity Ackroyd
+    telephone: 0330 313 9876
+    email: felicity.ackroyd@staracademies.org
+  - header: University of Chester
+    link: http://www.chester.ac.uk/
+    name: Jenn Simmonds
+    email: j.simmonds@chester.ac.uk
+  - header: University of Cumbria
+    link: http://www.cumbria.ac.uk/Courses/Subjects/Education/Postgraduate/DirectAssessmentOnlyRoute.aspx
+    name: Carolyn Reade
+    email: arolyn.reade@cumbria.ac.uk
+  South East:
+  - header: Astra School Centred Initial Teacher Training / Dr Challoner's Grammar
+      School
+    link: http://www.astra-alliance.com/285/the-assessment-only-route
+    name: Stephanie Rodgers
+    telephone: '01494 787573'
+    email: sro@challoners.org
+  - header: Bourton Meadow Initial Teacher Training Centre
+    link: http://www.bourtonmeadowittc.co.uk
+    name: Helen Byrom
+    telephone: '01280 823374'
+    email: hbyrom@bucksgfl.org.uk
+  - header: Canterbury Christ Church University
+    name: Keith Saunders
+    telephone: 01227 925555
+    email: pgadmissions@canterbury.ac.uk
+  - header: e-Qualitas
+    link: http://www.e-qualitas.org.uk/
+    name: Vivien Johnston
+    email: vivien@e-qualitas.co.uk
+  - header: George Abbot SCITT
+    link: http://www.georgeabbottraining.co.uk/assessment-only-route/
+    name: Lyndsay Cameron
+    telephone: '01483 888070'
+    email: lcameron@georgeabbot.surrey.sch.uk
+  - header: GLF Schools’ Teacher Training
+    link: https://www.glftt.org
+    name: Helen Shaw
+    telephone: '0208 716 4934'
+    email: info@glftt.org
+  - header: Kent and Medway Training
+    link: https://www.kmtraining.org.uk/
+    email: polly.butterfield-tracey@kmtraining.org.uk
+  - header: Oxford Brookes University
+    name: Lorna Shires
+    email: assessment-only-qts@brookes.ac.uk
+  - header: Surrey South Farnham SCITT
+    name: Eukaria Finch
+    telephone: 01252 717408
+    email: scitt@sfet.org.uk
+  - header: Thamesmead SCITT
+    name: Claire Lane
+    telephone: '01932 219412'
+    email: c.lane@thamesmead.surrey.sch.uk
+  - header: The Buckingham Partnership
+    link: http://www.bpscitt.uk/
+    name: Laura Whitty
+    telephone: '01280 827 377'
+    email: lwhitty@royallatin.org
+  - header: The Tommy Flowers SCITT
+    link: https://tommyflowersscitt.co.uk
+    name: Catherine Brown (senior administrator)
+    telephone: '01908 505030'
+    email: brownc@denbigh.net
+  - header: The University of Buckingham
+    link: http://www.buckingham.ac.uk/
+    name: Nikki Mugford
+    telephone: '01280 820219'
+    email: education@buckingham.ac.uk
+  - header: Two Mile Ash ITT Partnership
+    link: http://www.mkitt.co.uk/
+    name: Sarah Hand
+    telephone: '01908 533284'
+    email: info@mkitt.co.uk
+  - header: University of Chichester
+    link: http://www.chi.ac.uk/
+    email: ao@chi.ac.uk
+  - header: University of Reading
+    link: http://www.reading.ac.uk/
+    name: Marc Jacobs
+    telephone: '0118 378 2672'
+    email: m.l.jacobs@reading.ac.uk
+  - header: University of Southampton
+    link: http://www.southampton.ac.uk/education/postgraduate/itt_courses/assessment_only.page?
+    name: Jan Lewis
+    telephone: 023 8059 4669
+    email: j.v.lewis@soton.ac.uk
+  - header: University of Sussex
+    link: http://www.sussex.ac.uk/
+    name: Janet Steadman
+    email: l.harknett@sussex.ac.uk
+  - header: University of Winchester
+    link: http://www.winchester.ac.uk/pages/home.aspx
+    name: Keith Smith
+    email: ao@winchester.ac.uk
+  - header: West Berkshire Training Partnership
+    name: Emmeline Bird
+    telephone: 01635 42155
+    email: admin@itt-westberks.org
+  South West:
+  - header: Bath Spa University
+    link: http://www.bathspa.ac.uk/
+    name: Clare Furlonger
+    telephone: 01225 875650
+    email: assessmentonly@bathspa.ac.uk
+  - header: Cornwall School Centred Initial Teacher Training (Cornwall SCITT)
+    link: http://www.cornwallscitt.org/
+    name: Julie Bennett
+    telephone: '01872 267092'
+    email: juliebennett@truro-penwith.ac.uk
+  - header: Mid Somerset Consortium for Teacher Training
+    link: http://www.mscitt.org.uk/Routes/Assessment-only/
+    name: Sarah Lewis
+    telephone: '01458 449418'
+    email: office@mscitt.org.uk
+  - header: Somerset SCITT Consortium
+    link: https://www.sciltraining.co.uk
+    email: CLeoni@somerset.gov.uk
+  - header: The Learning Institute South West SCITT
+    link: http://www.learninginstitute.co.uk
+    name: Ania Glowczynska
+    telephone: 01726 891 745
+    email: info@learninginstitute.co.uk
+  - header: University of Gloucestershire
+    link: http://www.glos.ac.uk/study/Pages/study-with-us.aspx
+    name: Tim Adams
+    telephone: 01242 714638
+    email: qtsassessmentonly@glos.ac.uk
+  - header: Wessex Schools Training Partnership
+    name: Mike Petrus
+    telephone: 01202 662044
+    email: WSTP@poolehigh.poole.sch.uk
+  West Midlands:
+  - header: Birmingham City University
+    link: http://www.bcu.ac.uk/
+    name: Programme Leader
+    telephone: 0121 331 4627
+    email: assessmentonlyqts@bcu.ac.uk
+  - header: Keele and North Staffordshire Teacher Education
+    link: https://knste-shaw.org.uk/assessment-route
+    name: Tricia Locker
+    telephone: '01782 432538'
+    email: ao@knste-shaw.org.uk
+  - header: St. Joseph's College Stoke Secondary Partnership
+    link: http://www.stjosephstrentvale.com/teaching-school/partnership/
+    email: schater@stjosephsmail.com
+  - header: Staffordshire University
+    link: http://www.staffs.ac.uk/
+    name: Cath Hickling
+    email: c.hickling@staffs.ac.uk
+  - header: The National School of Education and Teaching, Coventry University
+    name: Carol Rowntree
+    telephone: 01327 850320
+    email: NSET@coventry.ac.uk
+  - header: The OAKS (Ormiston and Keele SCITT)
+    name: Rob Tweats
+    telephone: '01782 734332'
+    email: r.tweats@keele.ac.uk
+  - header: Titan Partnership Ltd
+    link: https://www.titanteachertraining.co.uk/itt-courses/assessment-only/
+    name: Sean Bates
+    telephone: 0121 607 1930
+    email: sean.bates@titan.org.uk
+  - header: University College Birmingham
+    link: http://www.ucb.ac.uk/home.aspx
+    name: Dr. Marj Jeavons
+    email: m.jeavons@ucb.ac.uk
+  - header: University of Warwick
+    link: https://warwick.ac.uk/fac/soc/cte/professionaldevelopment/assessmentonly/
+    name: CTE Admissions and Enrolment Team
+    email: cte.admissions@warwick.ac.uk
+  - header: University of Wolverhampton – primary
+    link: http://www.wlv.ac.uk/
+    email: AOPrimary@wlv.ac.uk
+  - header: University of Wolverhampton – secondary
+    link: http://www.wlv.ac.uk/
+    email: AOSecondary@wlv.ac.uk
+  - header: West Midlands Consortium
+    link: http://wmc.ttsonline.net/
+    name: Su Plant
+    telephone: '01952 200000'
+    email: ssplant@ttsonline.net
+  Yorkshire and the Humber:
+  - header: The Sheffield SCITT
+    link: https://www.sheffieldscitt.org.uk/
+    email: kbarna@hallamtsa.org.uk
+  - header: Bradford College
+    link: https://www.bradfordcollege.ac.uk/qts-assessment
+    name: Lee Parsell
+    telephone: 01274 088 368
+    email: l.parsell@bradfordcollege.ac.uk
+  - header: GORSE SCITT
+    name: Stephen McKenzie
+    telephone: '01134871777'
+    email: info@gorsescitt.org.uk
+  - header: Leeds Trinity University
+    name: Admissions
+    telephone: 0113 283 7123
+    email: admissions@leedstrinity.ac.uk
+  - header: North Lincolnshire SCITT Partnership
+    name: Jo Leedham
+    telephone: 01724 297950
+    email: jo.leedham@northlincs.gov.uk
+  - header: Three Counties Alliance SCITT
+    link: http://ytcascitt.co.uk/
+    name: Rebecca Turner-Loisel
+    telephone: '01977 657604'
+    email: ytca@minsthorpe.cc
+  - header: University of Hull
+    link: https://www.hull.ac.uk
+    telephone: '01482 466530'
+    email: FACE-admissions@hull.ac.uk
+  - header: Yorkshire and Humber Teacher Training
+    link: https://www.yhtt.co.uk
+    name: Chris Fletcher
+    telephone: '01482 349611'
+    email: cfletcher@yhtt.co.uk
+  National:
+  - header: TES Institute
+    link: https://www.tes.com/institute/assessment-only-route-qts?utm_source=nctl&utm_medium=referral&utm_content=AO-get-into-teaching-page&utm_campaign=web-referral
+    name: Mikki Burns
+    telephone: 0203 194 3200
+    email: Institute@tesglobal.com
+---
+
+A number of accredited providers have been approved to offer the 
+Assessment Only (AO) route to qualified teacher status (QTS). 
+If you wish to apply for the AO route you should apply directly to one if the 
+following approved providers:


### PR DESCRIPTION
### Trello card

https://trello.com/c/xa8Eotqv

### Context

We want to show a list of all assessment only providers on a page as series of cards

### Changes proposed in this pull request

1. Add a new assessment only providers page

