### PR TITLE
Secrets moved to terraform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,23 @@ jobs:
   turnstyle:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: Development
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
 
       - name: Check workflow concurrency
         uses: softprops/turnstyle@v1
@@ -33,17 +44,18 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_MESSAGE: Workflow concurrency issue
           SLACK_TITLE: Turnstyle failure ${{ github.workflow }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment: Development
     services:
       registry:
         image: registry:2
         ports:
           - 5000:5000
-    needs: turnstyle
+    needs: [ turnstyle ]
     steps:
 
       - name: Check out the repo
@@ -51,6 +63,16 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
 
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@master
@@ -75,8 +97,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+          username: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).DOCKER_USERNAME }}
+          password: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).DOCKER_PASSWORD }}
 
       - name: Build master and push to Docker Hub
         if: github.ref == 'refs/heads/master'
@@ -113,7 +135,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: cve
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"image": "${{ steps.sha.outputs.image }}"}'
 
       - name: Slack Notification
@@ -123,11 +145,12 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_MESSAGE: The Development ${{env.APPLICATION}} workflow has failed carrying out job ${{github.job}}
           SLACK_TITLE: Development Workflow Failure
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
 
   review:
     name: Review Deployment Process
-    needs: build
+    environment: Development
+    needs: [ build ]
     if: github.ref != 'refs/heads/master' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
@@ -137,11 +160,21 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Trigger Review Deployment
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "Review", "sha": "${{ github.sha }}" , "pr": "${{github.event.number}}"  }'
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -149,7 +182,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-review
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
           checkName: Deploy Review
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -170,7 +203,7 @@ jobs:
         if: contains(github.event.pull_request.user.login, 'dependabot') == false
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          github_token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          github_token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           labels: Review
 
       - name: Slack Notification
@@ -180,11 +213,12 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_TITLE: Failure preparing for Preview
           SLACK_MESSAGE: Failure with Review preperation for ${{env.APPLICATION}}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
 
   development:
     name: Development Deployment
-    needs: build
+    environment: Development
+    needs: [ build ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
@@ -197,11 +231,21 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Trigger Development Deployment
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "Development", "sha": "${{ github.sha }}"}'
           ref: ${{github.ref}}
 
@@ -209,7 +253,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
           checkName: Deploy Development
           ref: ${{github.ref}}
 
@@ -221,7 +265,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: owasp
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "dev"}'
 
       - name: Trigger Development Fix Network Policies
@@ -229,7 +273,7 @@ jobs:
         with:
          repo: DFE-Digital/get-into-teaching-api
          workflow: Fix Network policies 
-         token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+         token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
          inputs: '{"environment": "Development" }'
            
       - name: Generate Tag from PR Number
@@ -253,7 +297,8 @@ jobs:
 
   qa:
     name: Quality Assurance Deployment
-    needs: development
+    environment: Test
+    needs: [ development ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
@@ -263,11 +308,21 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Trigger Deployment to QA
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "Test", "sha": "${{ github.sha }}" }'
           ref: ${{github.ref}}
 
@@ -275,7 +330,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
           checkName: Deploy Test
           ref: ${{github.ref}}
 
@@ -290,12 +345,13 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_TITLE: Failure in Post-Development Deploy
           SLACK_MESSAGE: Failure with initialising QA deployment for ${{env.APPLICATION}}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
 
   cypress:
     name: Run Cypress Tests on QA
     runs-on: ubuntu-latest
-    needs: qa
+    environment: Test
+    needs: [ qa ]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -303,12 +359,22 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Trigger Cypress Tests (DFE-Digital/get-into-teaching-frontend-tests )
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           repo: DFE-Digital/get-into-teaching-frontend-tests
           workflow: Cypress
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"application": "APP" , "reference": "${{ github.sha }}" }'
           ref: refs/heads/master
 
@@ -316,7 +382,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
           checkName: ${{ github.sha }}
           ref: refs/heads/master
           repo: get-into-teaching-frontend-tests
@@ -329,6 +395,7 @@ jobs:
 
   production:
     name: Production Deployment
+    environment: Production
     runs-on: ubuntu-latest
     needs: [ cypress, development ]
     steps:
@@ -338,12 +405,22 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{needs.development.outputs.release_tag}}
-          TOKEN: ${{secrets.ACTIONS_API_ACCESS_TOKEN}}
+          TOKEN: ${{fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
 
       - name: Publish Release
         if: steps.tag_id.outputs.release_id
@@ -357,7 +434,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "Production", "sha": "${{ github.sha }}" }'
           ref: ${{github.ref}}
 
@@ -365,7 +442,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
           checkName: Deploy Production
           ref: ${{github.ref}}
 
@@ -378,7 +455,7 @@ jobs:
         with:
          repo: DFE-Digital/get-into-teaching-api
          workflow: Fix Network policies 
-         token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+         token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
          inputs: '{"environment": "Production" }'
 
       - name: Slack Release Notification
@@ -388,7 +465,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_SUCCESS}}
           SLACK_TITLE: "Release Published: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_NOTE_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_RELEASE_NOTE_WEBHOOK }}
           MSG_MINIMAL: true
 
       - name: Slack Notification
@@ -398,4 +475,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: Production Release ${{github.event.title}}
           SLACK_MESSAGE: Failure deploying Production release
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK'
 
       - name: Check workflow concurrency
         uses: softprops/turnstyle@v1
@@ -44,7 +44,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_MESSAGE: Workflow concurrency issue
           SLACK_TITLE: Turnstyle failure ${{ github.workflow }}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}
 
   build:
     name: Build
@@ -72,7 +72,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK, DOCKER-USERNAME, DOCKER-PASSWORD , ACTIONS-API-ACCESS-TOKEN'
 
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@master
@@ -97,8 +97,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
-          username: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).DOCKER_USERNAME }}
-          password: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).DOCKER_PASSWORD }}
+          username: ${{ steps.azSecret.outputs.DOCKER-USERNAME }}
+          password: ${{ steps.azSecret.outputs.DOCKER-PASSWORD }}
 
       - name: Build master and push to Docker Hub
         if: github.ref == 'refs/heads/master'
@@ -135,7 +135,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: cve
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"image": "${{ steps.sha.outputs.image }}"}'
 
       - name: Slack Notification
@@ -145,7 +145,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_MESSAGE: The Development ${{env.APPLICATION}} workflow has failed carrying out job ${{github.job}}
           SLACK_TITLE: Development Workflow Failure
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}
 
   review:
     name: Review Deployment Process
@@ -168,13 +168,13 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK'
 
       - name: Trigger Review Deployment
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "Review", "sha": "${{ github.sha }}" , "pr": "${{github.event.number}}"  }'
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -182,7 +182,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-review
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: Deploy Review
           ref: ${{ github.event.pull_request.head.ref }}
 
@@ -203,7 +203,7 @@ jobs:
         if: contains(github.event.pull_request.user.login, 'dependabot') == false
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          github_token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          github_token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           labels: Review
 
       - name: Slack Notification
@@ -213,7 +213,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_TITLE: Failure preparing for Preview
           SLACK_MESSAGE: Failure with Review preperation for ${{env.APPLICATION}}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}
 
   development:
     name: Development Deployment
@@ -239,13 +239,13 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK, ACTIONS-API-ACCESS-TOKEN'
 
       - name: Trigger Development Deployment
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "Development", "sha": "${{ github.sha }}"}'
           ref: ${{github.ref}}
 
@@ -253,7 +253,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: Deploy Development
           ref: ${{github.ref}}
 
@@ -265,16 +265,16 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: owasp
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "dev"}'
 
       - name: Trigger Development Fix Network Policies
         uses: benc-uk/workflow-dispatch@v1.1
         with:
-         repo: DFE-Digital/get-into-teaching-api
-         workflow: Fix Network policies 
-         token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
-         inputs: '{"environment": "Development" }'
+          repo: DFE-Digital/get-into-teaching-api
+          workflow: Fix Network policies 
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          inputs: '{"environment": "Development" }'
            
       - name: Generate Tag from PR Number
         id: tag_version
@@ -297,7 +297,7 @@ jobs:
 
   qa:
     name: Quality Assurance Deployment
-    environment: Test
+    environment: Development
     needs: [ development ]
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -316,13 +316,13 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK, ACTIONS-API-ACCESS-TOKEN'
 
       - name: Trigger Deployment to QA
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "Test", "sha": "${{ github.sha }}" }'
           ref: ${{github.ref}}
 
@@ -330,7 +330,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: Deploy Test
           ref: ${{github.ref}}
 
@@ -345,12 +345,12 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_ERROR}}
           SLACK_TITLE: Failure in Post-Development Deploy
           SLACK_MESSAGE: Failure with initialising QA deployment for ${{env.APPLICATION}}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}
 
   cypress:
     name: Run Cypress Tests on QA
     runs-on: ubuntu-latest
-    environment: Test
+    environment: Development
     needs: [ qa ]
     steps:
       - name: Check out the repo
@@ -367,14 +367,14 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'ACTIONS-API-ACCESS-TOKEN'
 
       - name: Trigger Cypress Tests (DFE-Digital/get-into-teaching-frontend-tests )
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           repo: DFE-Digital/get-into-teaching-frontend-tests
           workflow: Cypress
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"application": "APP" , "reference": "${{ github.sha }}" }'
           ref: refs/heads/master
 
@@ -382,7 +382,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: ${{ github.sha }}
           ref: refs/heads/master
           repo: get-into-teaching-frontend-tests
@@ -395,7 +395,7 @@ jobs:
 
   production:
     name: Production Deployment
-    environment: Production
+    environment: Development
     runs-on: ubuntu-latest
     needs: [ cypress, development ]
     steps:
@@ -413,14 +413,14 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK'
 
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{needs.development.outputs.release_tag}}
-          TOKEN: ${{fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          TOKEN: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
 
       - name: Publish Release
         if: steps.tag_id.outputs.release_id
@@ -434,7 +434,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "Production", "sha": "${{ github.sha }}" }'
           ref: ${{github.ref}}
 
@@ -442,7 +442,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: Deploy Production
           ref: ${{github.ref}}
 
@@ -455,7 +455,7 @@ jobs:
         with:
          repo: DFE-Digital/get-into-teaching-api
          workflow: Fix Network policies 
-         token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+         token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
          inputs: '{"environment": "Production" }'
 
       - name: Slack Release Notification
@@ -465,7 +465,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_SUCCESS}}
           SLACK_TITLE: "Release Published: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_RELEASE_NOTE_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-RELEASE-NOTE-WEBHOOK }}
           MSG_MINIMAL: true
 
       - name: Slack Notification
@@ -475,4 +475,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: Production Release ${{github.event.title}}
           SLACK_MESSAGE: Failure deploying Production release
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -26,7 +26,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK'
 
       - name: Scan image
         uses: anchore/scan-action@v2
@@ -47,6 +47,6 @@ jobs:
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}
           SLACK_MESSAGE: Pipeline Failure carrying out CVE Testing on ${{ github.event.inputs.image }}
           SLACK_TITLE: CVE Testing has failed

--- a/.github/workflows/cve.yml
+++ b/.github/workflows/cve.yml
@@ -10,12 +10,23 @@ jobs:
   cve:
     name: CVE Test
     runs-on: ubuntu-latest
+    environment: Development
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
 
       - name: Scan image
         uses: anchore/scan-action@v2
@@ -36,6 +47,6 @@ jobs:
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
           SLACK_MESSAGE: Pipeline Failure carrying out CVE Testing on ${{ github.event.inputs.image }}
           SLACK_TITLE: CVE Testing has failed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,6 @@ on:
       pr:
         description: Pull Request Reference
         required: false
-      project:
-        description: Name of Release Project
-        required: false
-        default: Teacher Training Adviser
 
 jobs:
   turnstyle:
@@ -30,6 +26,8 @@ jobs:
 
   deploy:
     name: Deploy ${{ github.event.inputs.environment }}
+    environment: 
+       name: ${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     needs: turnstyle
 
@@ -37,6 +35,7 @@ jobs:
       run:
         shell: bash
     steps:
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -52,11 +51,6 @@ jobs:
         run: |
              if [ "${{github.event.inputs.environment }}" == "Review" ]
              then
-                 echo ::set-output name=ARM_ACCESS_KEY::$(echo "${{ secrets.DEV_ARM_ACCESS_KEY  }}" )
-                 echo ::set-output name=RAILS_ENV::$(echo "rolling" )
-                 echo ::set-output name=RAILS_MASTER_KEY::$(echo "${{ secrets.RAILS_MASTER_KEY_ROLLING }}" )
-                 echo ::set-output name=HTTP_PASSWORD::$(echo "${{ secrets.HTTPAUTH_PASSWORD }}" )
-                 echo ::set-output name=HTTP_USERNAME::$(echo "${{ secrets.HTTPAUTH_USERNAME }}" )
                  echo ::set-output name=control::$(echo "review" )
                  pr_name="${{env.REVIEW_APPLICATION}}-${{github.event.inputs.pr}}"
                  echo ::set-output name=pr_name::${pr_name}
@@ -69,11 +63,6 @@ jobs:
 
              if [ "${{github.event.inputs.environment }}" == "Development" ]
              then
-                 echo ::set-output name=ARM_ACCESS_KEY::$(echo "${{ secrets.DEV_ARM_ACCESS_KEY  }}" )
-                 echo ::set-output name=RAILS_ENV::$(echo "rolling" )
-                 echo ::set-output name=RAILS_MASTER_KEY::$(echo "${{ secrets.RAILS_MASTER_KEY_ROLLING }}" )
-                 echo ::set-output name=HTTP_PASSWORD::$(echo "${{ secrets.HTTPAUTH_PASSWORD }}" )
-                 echo ::set-output name=HTTP_USERNAME::$(echo "${{ secrets.HTTPAUTH_USERNAME }}" )
                  echo ::set-output name=control::$(echo "dev" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-dev" )
                  echo ::set-output name=key::"app.dev.terraform"
@@ -82,11 +71,6 @@ jobs:
 
              if [ "${{github.event.inputs.environment }}" == "Test" ]
              then
-                 echo ::set-output name=ARM_ACCESS_KEY::$(echo "${{ secrets.TEST_ARM_ACCESS_KEY  }}" )
-                 echo ::set-output name=RAILS_ENV::$(echo "preprod" )
-                 echo ::set-output name=RAILS_MASTER_KEY::$(echo "${{ secrets.RAILS_MASTER_KEY_PREPROD }}" )
-                 echo ::set-output name=HTTP_PASSWORD::$(echo "${{ secrets.HTTPAUTH_PASSWORD }}" )
-                 echo ::set-output name=HTTP_USERNAME::$(echo "${{ secrets.HTTPAUTH_USERNAME }}" )
                  echo ::set-output name=control::$(echo "test" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-test" )
                  echo ::set-output name=key::"app.test.terraform"
@@ -95,16 +79,20 @@ jobs:
 
              if [ "${{github.event.inputs.environment }}" == "Production" ]
              then
-                 echo ::set-output name=ARM_ACCESS_KEY::$(echo "${{ secrets.PROD_ARM_ACCESS_KEY  }}" )
-                 echo ::set-output name=RAILS_ENV::$(echo "production" )
-                 echo ::set-output name=RAILS_MASTER_KEY::$(echo "${{ secrets.RAILS_MASTER_KEY_PRODUCTION }}" )
-                 echo ::set-output name=HTTP_PASSWORD::$(echo "" )
-                 echo ::set-output name=HTTP_USERNAME::$(echo "" )
-                 echo ::set-output name=control::$(echo "production" )
                  echo ::set-output name=healthcheck::$(echo "${{env.PAAS_APPLICATION_NAME}}-prod" )
                  echo ::set-output name=key::"app.production.terraform"
                  echo ::set-output name=docker_image::${{env.DOCKERHUB_REPOSITORY}}:sha-${{ steps.sha.outputs.short}}
              fi
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'CONTENT-KEYS'
 
       - uses: hashicorp/setup-terraform@v1.3.2
         with:
@@ -133,26 +121,16 @@ jobs:
             terraform plan -var-file=${{steps.variables.outputs.control}}.env.tfvars -out plan
             terraform apply -auto-approve plan
         env:
-          ARM_ACCESS_KEY: ${{ steps.variables.outputs.ARM_ACCESS_KEY  }}
-          TF_VAR_user: ${{ secrets.GOVUKPAAS_USERNAME  }}
-          TF_VAR_password: ${{ secrets.GOVUKPAAS_PASSWORD  }}
-          TF_VAR_RAILS_ENV: ${{ steps.variables.outputs.RAILS_ENV  }}
+          ARM_ACCESS_KEY:               ${{ secrets.ARM_ACCESS_KEY  }}
           TF_VAR_paas_app_docker_image: ${{ steps.variables.outputs.docker_image}}
-          TF_VAR_RAILS_MASTER_KEY: ${{ steps.variables.outputs.RAILS_MASTER_KEY  }}
-          TF_VAR_HTTPAUTH_PASSWORD: ${{ steps.variables.outputs.HTTP_PASSWORD  }}
-          TF_VAR_HTTPAUTH_USERNAME: ${{ steps.variables.outputs.HTTP_USERNAME  }}
-          TF_VAR_docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          TF_VAR_docker_password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
-          TF_VAR_sc_username: "DfEStatusCake"
-          TF_VAR_sc_api_key: ${{ secrets.STATUS_CAKE_API  }}
-
+          TF_VAR_AZURE_CREDENTIALS:     ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Smoke tests
         run: |
             tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "${{ steps.sha.outputs.short }}"
         env:
-          HTTPAUTH_PASSWORD: ${{ steps.variables.outputs.HTTP_PASSWORD }}
-          HTTPAUTH_USERNAME: ${{ steps.variables.outputs.HTTP_USERNAME }}
+          HTTPAUTH_PASSWORD: ${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTP_PASSWORD }}
+          HTTPAUTH_USERNAME: ${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTP_USERNAME }}
 
       - name: Update ${{ github.event.inputs.environment }} status
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'CONTENT-KEYS'
+           secrets: 'HTTP-USERNAME, HTTP-PASSWORD'
 
       - uses: hashicorp/setup-terraform@v1.3.2
         with:
@@ -129,8 +129,8 @@ jobs:
         run: |
             tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "${{ steps.sha.outputs.short }}"
         env:
-          HTTPAUTH_PASSWORD: ${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTP_PASSWORD }}
-          HTTPAUTH_USERNAME: ${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTP_USERNAME }}
+          HTTPAUTH_PASSWORD: ${{ steps.azSecret.outputs.HTTP-PASSWORD }}
+          HTTPAUTH_USERNAME: ${{ steps.azSecret.outputs.HTTP-USERNAME }}
 
       - name: Update ${{ github.event.inputs.environment }} status
         if: always()

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -28,7 +28,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK'
 
       - name: Setup Environment Variables
         id: variables
@@ -62,4 +62,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: Failure Closing Review
           SLACK_MESSAGE: Failure closing ${{env.APPLICATION}} review
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }} 
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }} 

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   destroy:
-    name: Destroy ${{ github.event.inputs.environment }}
+    name: Destroy 
+    environment:
+       name: Review
     runs-on: ubuntu-latest
 
     defaults:
@@ -18,18 +20,20 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Setup Environment Variables
         id: variables
         run: |
-                 echo ::set-output name=ARM_ACCESS_KEY::$(echo "${{ secrets.DEV_ARM_ACCESS_KEY  }}" )
-                 echo ::set-output name=pr_name::${{env.REVIEW_APPLICATION}}-${{github.event.number}}
-                 echo ::set-output name=url::"https://${{env.REVIEW_APPLICATION}}-${{github.event.number}}.${{env.DOMAIN}}"
-                 echo ::set-output name=RAILS_ENV::$(echo "rolling" )
-                 echo ::set-output name=RAILS_MASTER_KEY::$(echo "${{ secrets.RAILS_MASTER_KEY_ROLLING }}" )
-                 echo ::set-output name=HTTP_PASSWORD::$(echo "${{ secrets.HTTPAUTH_PASSWORD }}" )
-                 echo ::set-output name=HTTP_USERNAME::$(echo "${{ secrets.HTTPAUTH_USERNAME }}" )
-                 echo ::set-output name=control::$(echo "dev" )
-                 echo ::set-output name=healthcheck::"${{env.REVIEW_APPLICATION}}-${{github.event.inputs.pr}}"
+              echo ::set-output name=pr_name::${{env.REVIEW_APPLICATION}}-${{github.event.number}}
 
       - uses: hashicorp/setup-terraform@v1.3.2
         with:
@@ -48,19 +52,8 @@ jobs:
             terraform init -backend-config=review.bk.vars -backend-config="key=${{steps.variables.outputs.pr_name}}.tfstate"
             terraform destroy -var-file=review.env.tfvars -auto-approve
         env:
-          ARM_ACCESS_KEY: ${{ steps.variables.outputs.ARM_ACCESS_KEY  }}
-          TF_VAR_user: ${{ secrets.GOVUKPAAS_USERNAME  }}
-          TF_VAR_password: ${{ secrets.GOVUKPAAS_PASSWORD  }}
-          TF_VAR_RAILS_ENV: ${{ steps.variables.outputs.RAILS_ENV  }}
-          TF_VAR_RAILS_MASTER_KEY: ${{ steps.variables.outputs.RAILS_MASTER_KEY  }}
-          TF_VAR_HTTPAUTH_PASSWORD: ${{ steps.variables.outputs.HTTP_PASSWORD  }}
-          TF_VAR_HTTPAUTH_USERNAME: ${{ steps.variables.outputs.HTTP_USERNAME  }}
-          TF_VAR_docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          TF_VAR_docker_password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
-          TF_VAR_paas_app_route_name: DUMMY
-          TF_VAR_sc_username: DfEStatusCake
-          TF_VAR_sc_api_key: ${{ secrets.STATUS_CAKE_API }}
-
+          ARM_ACCESS_KEY:               ${{ secrets.ARM_ACCESS_KEY  }}
+          TF_VAR_AZURE_CREDENTIALS:     ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Slack Notification
         if: failure()
@@ -69,4 +62,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: Failure Closing Review
           SLACK_MESSAGE: Failure closing ${{env.APPLICATION}} review
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }} 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -35,14 +35,14 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'SLACK-WEBHOOK, SLACK-RELEASE-NOTE-WEBHOOK, ACTIONS-API-ACCESS-TOKEN'
 
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{ github.event.inputs.tag }}
-          TOKEN: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          TOKEN: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
 
       - name: Check if found
         if: steps.tag_id.outputs.found == 0
@@ -54,7 +54,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           inputs: '{"environment": "${{github.event.inputs.environment}}" , "sha": "${{steps.tag_id.outputs.release_sha}}"  }'
           ref: "${{github.ref}}"
 
@@ -62,7 +62,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
           checkName: Deploy ${{github.event.inputs.environment}}
           ref: "${{github.ref}}"
 
@@ -81,7 +81,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_SUCCESS}}
           SLACK_TITLE: "Release Published to ${{github.event.inputs.environment}}: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_RELEASE_NOTE_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-RELEASE-NOTE-WEBHOOK }}
           MSG_MINIMAL: true
 
       - name: Slack Notification
@@ -91,4 +91,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: "Manual Release Failed: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: Failure deploying ${{github.event.inputs.environment}} release
-          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   manual:
     name: Deploy to ${{github.event.inputs.environment}}
+    environment:
+       name: ${{github.event.inputs.environment}}
+
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -24,12 +27,22 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Get Release Id from Tag
         id: tag_id
         uses: DFE-Digital/github-actions/DraftReleaseByTag@master
         with:
           TAG: ${{ github.event.inputs.tag }}
-          TOKEN: ${{secrets.ACTIONS_API_ACCESS_TOKEN}}
+          TOKEN: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
 
       - name: Check if found
         if: steps.tag_id.outputs.found == 0
@@ -41,7 +54,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           inputs: '{"environment": "${{github.event.inputs.environment}}" , "sha": "${{steps.tag_id.outputs.release_sha}}"  }'
           ref: "${{github.ref}}"
 
@@ -49,7 +62,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-deploy
         with:
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
+          token: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).ACTIONS_API_ACCESS_TOKEN }}
           checkName: Deploy ${{github.event.inputs.environment}}
           ref: "${{github.ref}}"
 
@@ -68,7 +81,7 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_SUCCESS}}
           SLACK_TITLE: "Release Published to ${{github.event.inputs.environment}}: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: ${{steps.tag_id.outputs.release_body}}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_NOTE_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_RELEASE_NOTE_WEBHOOK }}
           MSG_MINIMAL: true
 
       - name: Slack Notification
@@ -78,4 +91,4 @@ jobs:
           SLACK_COLOR: ${{env.SLACK_FAILURE}}
           SLACK_TITLE: "Manual Release Failed: ${{steps.tag_id.outputs.release_name}}"
           SLACK_MESSAGE: Failure deploying ${{github.event.inputs.environment}} release
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -23,7 +23,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS , CONTENT-KEYS'
+           secrets: 'HTTP-PASSWORD, HTTP-USERNAME, SLACK-WEBHOOK'
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -33,7 +33,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
-          target: 'https://${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTPAUTH_USERNAME }}:${{ fromJson( steps.azSecret.outputs.CONTENT-COMMON-KEYS).HTTPAUTH_PASSWORD }}@${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
+          target: 'https://${{ steps.azSecret.outputs.HTTP-USERNAME }}:${{ steps.azSecret.outputs.HTTP-PASSWORD }}@${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-a'
 
@@ -44,4 +44,4 @@ jobs:
            SLACK_COLOR: ${{env.SLACK_FAILURE}}
            SLACK_MESSAGE: 'Pipeline Failure carrying out OWASP Testing on https://${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
            SLACK_TITLE: 'Failure: OWSAP Testing has failed on ${{ github.event.inputs.environment }}'
-           SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}
+           SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -10,9 +10,20 @@ jobs:
   owasp:
     name: 'OWASP Test ${{ github.event.inputs.environment }}'
     runs-on: ubuntu-latest
+    environment: Development
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS , CONTENT-KEYS'
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -22,7 +33,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'
-          target: 'https://${{ secrets.HTTPAUTH_USERNAME }}:${{ secrets.HTTPAUTH_PASSWORD }}@${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
+          target: 'https://${{ fromJson( steps.azSecret.outputs.CONTENT-KEYS).HTTPAUTH_USERNAME }}:${{ fromJson( steps.azSecret.outputs.CONTENT-COMMON-KEYS).HTTPAUTH_PASSWORD }}@${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-a'
 
@@ -33,4 +44,4 @@ jobs:
            SLACK_COLOR: ${{env.SLACK_FAILURE}}
            SLACK_MESSAGE: 'Pipeline Failure carrying out OWASP Testing on https://${{env.PAAS_APPLICATION_NAME}}-${{ github.event.inputs.environment }}.${{env.DOMAIN}}/'
            SLACK_TITLE: 'Failure: OWSAP Testing has failed on ${{ github.event.inputs.environment }}'
-           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+           SLACK_WEBHOOK: ${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).SLACK_WEBHOOK }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -8,7 +8,18 @@ jobs:
   attach-to-trello:
     name: Link Trello card to this PR
     runs-on: ubuntu-latest
+    environment: Development
     steps:
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'COMMON-KEYS'
+
       - name: Extract Pull Request url
         id: pr-url
         run: |
@@ -35,6 +46,6 @@ jobs:
             --fail \
             --request POST \
             --url 'https://api.trello.com/1/cards/${{ steps.trello-id.outputs.id }}/actions/comments' \
-            --data-urlencode "key=${{ secrets.TRELLO_KEY }}" \
-            --data-urlencode "token=${{ secrets.TRELLO_TOKEN }}" \
+            --data-urlencode "key=${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).TRELLO_KEY }}" \
+            --data-urlencode "token=${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).TRELLO_TOKEN }}" \
             --data-urlencode "text=${{ steps.pr-url.outputs.url }}"

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -18,7 +18,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'COMMON-KEYS'
+           secrets: 'TRELLO-KEY, TRELLO-TOKEN'
 
       - name: Extract Pull Request url
         id: pr-url
@@ -46,6 +46,6 @@ jobs:
             --fail \
             --request POST \
             --url 'https://api.trello.com/1/cards/${{ steps.trello-id.outputs.id }}/actions/comments' \
-            --data-urlencode "key=${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).TRELLO_KEY }}" \
-            --data-urlencode "token=${{ fromJson( steps.azSecret.outputs.COMMON-KEYS).TRELLO_TOKEN }}" \
+            --data-urlencode "key=${{ steps.azSecret.outputs.TRELLO-KEY }}" \
+            --data-urlencode "token=${{ steps.azSecret.outputs.TRELLO-TOKEN }}" \
             --data-urlencode "text=${{ steps.pr-url.outputs.url }}"

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,3 +1,7 @@
+locals {
+  environment_map = { HTTPAUTH_PASSWORD = data.azurerm_key_vault_secret.http_password.value, HTTPAUTH_USERNAME = data.azurerm_key_vault_secret.http_username.value }
+}
+
 resource cloudfoundry_app app_application {
   name         = var.paas_app_application_name
   space        = data.cloudfoundry_space.space.id
@@ -15,8 +19,8 @@ resource cloudfoundry_app app_application {
   }
 
   docker_credentials = {
-    username = local.devops_secrets["DOCKER_USERNAME"]
-    password = local.devops_secrets["DOCKER_PASSWORD"]
+    username = data.azurerm_key_vault_secret.docker_username.value
+    password = data.azurerm_key_vault_secret.docker_password.value
   }
 
   service_binding {
@@ -38,12 +42,7 @@ resource cloudfoundry_app app_application {
     }
   }
 
-  environment = {
-    HTTPAUTH_PASSWORD = local.application_secrets["HTTPAUTH_PASSWORD"]
-    HTTPAUTH_USERNAME = local.application_secrets["HTTPAUTH_USERNAME"]
-    RAILS_ENV         = local.application_secrets["RAILS_ENV"]
-    RAILS_MASTER_KEY  = local.application_secrets["RAILS_MASTER_KEY"]
-  }
+  environment = merge(local.application_secrets, local.environment_map)
 }
 
 

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,4 +1,4 @@
-resource "cloudfoundry_app" "app_application" {
+resource cloudfoundry_app app_application {
   name         = var.paas_app_application_name
   space        = data.cloudfoundry_space.space.id
   docker_image = var.paas_app_docker_image
@@ -7,7 +7,7 @@ resource "cloudfoundry_app" "app_application" {
   memory       = 1024
   timeout      = 180
   instances    = var.instances
-  dynamic "service_binding" {
+  dynamic service_binding {
     for_each = data.cloudfoundry_user_provided_service.logging
     content {
       service_instance = service_binding.value["id"]
@@ -15,8 +15,8 @@ resource "cloudfoundry_app" "app_application" {
   }
 
   docker_credentials = {
-    username = var.docker_username
-    password = var.docker_password
+    username = local.devops_secrets["DOCKER_USERNAME"]
+    password = local.devops_secrets["DOCKER_PASSWORD"]
   }
 
   service_binding {
@@ -31,19 +31,18 @@ resource "cloudfoundry_app" "app_application" {
     route = cloudfoundry_route.app_route_internal.id
   }
 
-  dynamic "routes" {
+  dynamic routes {
     for_each = data.cloudfoundry_route.app_route_internet
     content {
       route = routes.value["id"]
     }
   }
 
-
   environment = {
-    HTTPAUTH_PASSWORD = var.HTTPAUTH_PASSWORD
-    HTTPAUTH_USERNAME = var.HTTPAUTH_USERNAME
-    RAILS_ENV         = var.RAILS_ENV
-    RAILS_MASTER_KEY  = var.RAILS_MASTER_KEY
+    HTTPAUTH_PASSWORD = local.application_secrets["HTTPAUTH_PASSWORD"]
+    HTTPAUTH_USERNAME = local.application_secrets["HTTPAUTH_USERNAME"]
+    RAILS_ENV         = local.application_secrets["RAILS_ENV"]
+    RAILS_MASTER_KEY  = local.application_secrets["RAILS_MASTER_KEY"]
   }
 }
 

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -1,0 +1,19 @@
+data azurerm_key_vault vault {
+  name                = var.azure_key_vault
+  resource_group_name = var.azure_resource_group
+}
+
+data azurerm_key_vault_secret Application {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "CONTENT-KEYS"
+}
+
+data azurerm_key_vault_secret DevOps {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "COMMON-KEYS"
+}
+
+locals {
+  devops_secrets      = jsondecode(data.azurerm_key_vault_secret.DevOps.value)
+  application_secrets = jsondecode(data.azurerm_key_vault_secret.Application.value)
+}

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -3,17 +3,51 @@ data azurerm_key_vault vault {
   resource_group_name = var.azure_resource_group
 }
 
-data azurerm_key_vault_secret Application {
+data azurerm_key_vault_secret application {
   key_vault_id = data.azurerm_key_vault.vault.id
   name         = "CONTENT-KEYS"
 }
 
-data azurerm_key_vault_secret DevOps {
-  key_vault_id = data.azurerm_key_vault.vault.id
-  name         = "COMMON-KEYS"
+locals {
+  application_secrets = yamldecode(data.azurerm_key_vault_secret.application.value)
 }
 
-locals {
-  devops_secrets      = jsondecode(data.azurerm_key_vault_secret.DevOps.value)
-  application_secrets = jsondecode(data.azurerm_key_vault_secret.Application.value)
+data azurerm_key_vault_secret docker_username {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "DOCKER-USERNAME"
+}
+
+data azurerm_key_vault_secret docker_password {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "DOCKER-PASSWORD"
+}
+
+data azurerm_key_vault_secret paas_username {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "PAAS-USERNAME"
+}
+
+data azurerm_key_vault_secret paas_password {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "PAAS-PASSWORD"
+}
+
+data azurerm_key_vault_secret statuscake_username {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "SC-USERNAME"
+}
+
+data azurerm_key_vault_secret statuscake_password {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "SC-PASSWORD"
+}
+
+data azurerm_key_vault_secret http_username {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "HTTP-USERNAME"
+}
+
+data azurerm_key_vault_secret http_password {
+  key_vault_id = data.azurerm_key_vault.vault.id
+  name         = "HTTP-PASSWORD"
 }

--- a/terraform/paas/dev.env.tfvars
+++ b/terraform/paas/dev.env.tfvars
@@ -6,3 +6,5 @@ logging                   = 0
 additional_routes         = 0
 instances                 = 1
 alerts                    = {}
+azure_key_vault           = "s146d01-kv"
+azure_resource_group      = "s146d01-rg"

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -4,17 +4,19 @@ paas_app_application_name  = "get-into-teaching-app-prod"
 paas_redis_1_name          = "get-into-teaching-prod-redis-svc"
 paas_additional_route_name = "beta-getintoteaching"
 instances                  = 2
-alerts = {	
-  GiT_App_Production_Healthcheck = {	
-    website_name  = "Get Into Teaching Website (Production)"	
-    website_url   = "https://beta-getintoteaching.education.gov.uk/healthcheck.json"	
-    test_type     = "HTTP"	
-    check_rate    = 60	
-    contact_group = [185037]	
-    trigger_rate  = 0	
+azure_key_vault            = "s146p01-kv"
+azure_resource_group       = "s146p01-rg"
+alerts = {
+  GiT_App_Production_Healthcheck = {
+    website_name  = "Get Into Teaching Website (Production)"
+    website_url   = "https://beta-getintoteaching.education.gov.uk/healthcheck.json"
+    test_type     = "HTTP"
+    check_rate    = 60
+    contact_group = [185037]
+    trigger_rate  = 0
     confirmations = 1
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
     status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
 
-  }	
+  }
 }

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -1,14 +1,27 @@
 provider "cloudfoundry" {
   api_url  = var.api_url
-  user     = var.user
-  password = var.password
+  user     = local.devops_secrets["PAAS_USERNAME"]
+  password = local.devops_secrets["PAAS_PASSWORD"]
 }
 
 provider statuscake {
-  username = var.sc_username
-  apikey   = var.sc_api_key
+  username = local.devops_secrets["SC_USERNAME"]
+  apikey   = local.devops_secrets["SC_PASSWORD"]
 }
 
+locals {
+  azure_credentials      = jsondecode( var.AZURE_CREDENTIALS )
+}
+
+provider "azurerm" {
+  version                    = ">= 2.0"
+  skip_provider_registration = true
+  features {}
+  subscription_id = local.azure_credentials.subscriptionId
+  client_id       = local.azure_credentials.clientId
+  client_secret   = local.azure_credentials.clientSecret
+  tenant_id       = local.azure_credentials.tenantId
+}
 
 terraform {
   required_version = ">= 0.13.4"

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -1,16 +1,16 @@
 provider "cloudfoundry" {
   api_url  = var.api_url
-  user     = local.devops_secrets["PAAS_USERNAME"]
-  password = local.devops_secrets["PAAS_PASSWORD"]
+  user     = data.azurerm_key_vault_secret.paas_username.value
+  password = data.azurerm_key_vault_secret.paas_password.value
 }
 
 provider statuscake {
-  username = local.devops_secrets["SC_USERNAME"]
-  apikey   = local.devops_secrets["SC_PASSWORD"]
+  username = data.azurerm_key_vault_secret.statuscake_username.value
+  apikey   = data.azurerm_key_vault_secret.statuscake_password.value
 }
 
 locals {
-  azure_credentials      = jsondecode( var.AZURE_CREDENTIALS )
+  azure_credentials = jsondecode(var.AZURE_CREDENTIALS)
 }
 
 provider "azurerm" {

--- a/terraform/paas/review.env.tfvars
+++ b/terraform/paas/review.env.tfvars
@@ -1,6 +1,8 @@
-paas_space        = "get-into-teaching"
-paas_redis_1_name = "get-into-teaching-dev-redis-svc"
-logging           = 0
-additional_routes = 0
-instances         = 1
-alerts            = {}
+paas_space           = "get-into-teaching"
+paas_redis_1_name    = "get-into-teaching-dev-redis-svc"
+logging              = 0
+additional_routes    = 0
+instances            = 1
+alerts               = {}
+azure_key_vault      = "s146d01-kv"
+azure_resource_group = "s146d01-rg"

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -10,7 +10,7 @@ resource statuscake_test alert {
   confirmations = each.value.confirmations
   custom_header = each.value.custom_header
   status_codes  = each.value.status_codes
-  basic_user    = var.HTTPAUTH_USERNAME
-  basic_pass    = var.HTTPAUTH_PASSWORD
+  basic_user    = local.application_secrets["HTTPAUTH_USERNAME"]
+  basic_pass    = local.application_secrets["HTTPAUTH_PASSWORD"]
   test_tags     = ["GIT", "BETA"]
 }

--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -10,7 +10,7 @@ resource statuscake_test alert {
   confirmations = each.value.confirmations
   custom_header = each.value.custom_header
   status_codes  = each.value.status_codes
-  basic_user    = local.application_secrets["HTTPAUTH_USERNAME"]
-  basic_pass    = local.application_secrets["HTTPAUTH_PASSWORD"]
+  basic_user    = data.azurerm_key_vault_secret.http_username.value
+  basic_pass    = data.azurerm_key_vault_secret.http_password.value
   test_tags     = ["GIT", "BETA"]
 }

--- a/terraform/paas/test.env.tfvars
+++ b/terraform/paas/test.env.tfvars
@@ -5,3 +5,5 @@ paas_redis_1_name          = "get-into-teaching-test-redis-svc"
 paas_additional_route_name = "staging-getintoteaching"
 additional_routes          = 1
 alerts                     = {}
+azure_key_vault            = "s146t01-kv"
+azure_resource_group       = "s146t01-rg"

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -18,7 +18,7 @@ variable "paas_space" {
 }
 
 variable "paas_org_name" {
-  default = "dfe-teacher-services"
+  default = "dfe"
 }
 
 variable "instances" {

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -1,16 +1,13 @@
 # These settings are for the sandbox and should mainly be overriden by TF_VARS 
 # or set with environment variables TF_VAR_xxxx
 
-variable user {
-  default = "get-into-teaching-tech@digital.education.gov.uk"
-}
-
 variable api_url {
   default = "https://api.london.cloud.service.gov.uk"
 }
 
-variable password {}
-
+variable AZURE_CREDENTIALS {}
+variable azure_key_vault {}
+variable azure_resource_group {}
 
 variable "application_stopped" {
   default = false
@@ -27,10 +24,6 @@ variable "paas_org_name" {
 variable "instances" {
   default = 1
 }
-
-variable "docker_username" {}
-variable "docker_password" {}
-
 
 variable "logging" {
   default = 1
@@ -66,14 +59,7 @@ variable "strategy" {
   default = "blue-green"
 }
 
-variable "HTTPAUTH_PASSWORD" {}
-variable "HTTPAUTH_USERNAME" {}
-variable "RAILS_ENV" {}
-variable "RAILS_MASTER_KEY" {}
-
-
-variable "sc_username" {}
-variable "sc_api_key" {}
 variable "alerts" {
   type = map
 }
+


### PR DESCRIPTION
### [Secrets](https://trello.com/c/flZVRexA/384-platform-review-storage-of-secrets)

### Context
Github secrets have a few limitations and we are moving them to Azure Key Vault as per  [Key Vault](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2413854732/Azure+Key+Vault)

### Changes proposed in this pull request
Secrets purely used by the application should be only used by Terraform and are in YAML format, so the developers can suck down the whole YAML file, edit it and then push it up. Keeping secrets constant, it also allows for a new environment variable to be added to terraform without extensive code changes.

Devops secrets were going to be the same, but it was discovered that GitHub could expose them when converting them from json to individual secrets. This has meant each devops secret is a standalone secret.

### Guidance to review
No Application Changes
Secrets will be removed from github secrets at a later date
The statuscake devops variables are the only two variables not used in GitHub Actions, it seemed a lot of effort to manage these two variables as a map and the rest as individual variables. so they remain individual