### PR TITLE
Transition home page to new layout

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -1,10 +1,9 @@
 ---
-  layout: "layouts/home_old"
+  layout: "layouts/home"
   title: "Inspire the next generation"
   deepheader: true
   mailinglist: true
   fullwidth: true
-  hide_page_helpful_question: true
   lid_pixel_event: "Homepage"
   subtitle: "Get information and support to help you become a teacher"
   image: "media/images/hero-home-dt.jpg"

--- a/content/home/_featured_content.html.erb
+++ b/content/home/_featured_content.html.erb
@@ -1,10 +1,12 @@
-<div class="featured-content">
-  <div class="container-1000 content">
-    <div class="strapline strapline--small strapline--blue">Explore</div>
-    <div class="featured-content__items">
-      <%= render "content/home/featured_content/why_sign_up_for_a_tta" %>
-      <%= render "content/home/featured_content/swapping_senior_management_for_students" %>
-      <%= render "content/home/featured_content/apply_for_teacher_training" %>
+<section class="container">
+  <article class="markdown overhang fullwidth">
+    <h2>Explore</h2>
+    <div class="featured-content">
+      <div class="featured-content__items">
+        <%= render "content/home/featured_content/why_sign_up_for_a_tta" %>
+        <%= render "content/home/featured_content/swapping_senior_management_for_students" %>
+        <%= render "content/home/featured_content/apply_for_teacher_training" %>
+      </div>
     </div>
-  </div>
-</div>
+  </article>
+</section>

--- a/content/home/_find_an_event_near_you.html.erb
+++ b/content/home/_find_an_event_near_you.html.erb
@@ -1,17 +1,16 @@
-<div class="home-find-event">
-    <div class="container-1000 content">
-      <div class="home-find-event__inner">
-        <div class="strapline strapline--small strapline--blue">Events</div>
+<div class="colored-stripe colored-stripe--with-title colored-stripe--grey">
+  <section class="container">
+    <article class="markdown overhang">
+      <h2 class="colored-stripe__title">Events</h2>
+      <div class="colored-stripe__content">
+        <h1>Speak to a teacher at one of our online events.</h1>
 
-        <div class="home-inset-content">
-          <h1>Speak to a teacher at one of our online events.</h1>
-
-          <div>
-            <p>Come to a free teaching event and find out how you can train to become a teacher.</p>
-            <a class="call-to-action-button" href="/events">Find <span>Events</span></a>
-          </div>
+        <div>
+          <p>Come to a free teaching event and find out how you can train to become a teacher.</p>
+          <a class="call-to-action-button" href="/events">Find <span>Events</span></a>
         </div>
       </div>
-      <div class="home-find-event__img"></div>
-    </div>
+    </article>
+  </section>
+  <div class="home-find-event-img"></div>
 </div>

--- a/content/home/_home_quote.html.erb
+++ b/content/home/_home_quote.html.erb
@@ -1,9 +1,13 @@
-<div class="home-quote">
-    <div class="container-1000">
+<div class="colored-stripe colored-stripe--yellow">
+  <div class="home-quote-img" style="background-image: url('assets/images/home-quote.jpg')"></div>
+  <section class="container">
+    <article class="markdown overhang fullwidth">
+      <div class="colored-stripe__content">
         <div class="home-quote__text">
-            <blockquote class="home-quote__quote">The best part of teaching for me is seeing that lightbulb moment when a child suddenly understands something they didn’t before.</blockquote>
-            <span class="home-quote__citation">Simon, teacher</span>
+          <blockquote class="home-quote__quote">The best part of teaching for me is seeing that lightbulb moment when a child suddenly understands something they didn’t before.</blockquote>
+         <span class="home-quote__citation">Simon, teacher</span>
         </div>
-    </div>
-    <div class="home-quote__img" style="background-image: url('assets/images/home-quote.jpg')"></div>
+      </div>
+    </article>
+  </section>
 </div>

--- a/content/home/_life_as_a_teacher.html.erb
+++ b/content/home/_life_as_a_teacher.html.erb
@@ -1,4 +1,8 @@
-<div class="cta-links container-1000">
-  <%= render "content/home/life_as_a_teacher/teaching_as_a_career" %>
-  <%= render "content/home/life_as_a_teacher/salaries_and_benefits" %>
-</div>
+<section class="container">
+  <article class="markdown overhang fullwidth">
+    <div class="cta-links">
+      <%= render "content/home/life_as_a_teacher/teaching_as_a_career" %>
+      <%= render "content/home/life_as_a_teacher/salaries_and_benefits" %>
+    </div>
+  </article>
+</section>

--- a/content/home/_steps_home.html.erb
+++ b/content/home/_steps_home.html.erb
@@ -1,42 +1,42 @@
-<div class="steps-home">
-    <div class="container-1000">
-        <div class="strapline strapline--small strapline--blue">Steps</div>
+<section class="container">
+  <article class="markdown overhang fullwidth">
+    <h2>Steps</h2>
 
-        <div class="home-inset-content">
-          <h1>Discover the steps to become a teacher.</h1>
+    <div class="home-inset-content">
+      <h1>Discover the steps to become a teacher.</h1>
 
-          <div class="steps__wrapper">
-            <div class="steps__step">
-                <div class="steps__number"><span>1</span></div>
-                <a href="/steps-to-become-a-teacher" class="steps__link">
-                    <span>Check your qualifications</span>
-                </a>
-            </div>
-            <div class="steps__step">
-                <div class="steps__number"><span>2</span></div>
-                <a href="/steps-to-become-a-teacher#step-2" class="steps__link">
-                    <span>Find out about teaching and training</span>
-                </a>
-            </div>
-            <div class="steps__step">
-                <div class="steps__number"><span>3</span></div>
-                <a href="/steps-to-become-a-teacher#step-3" class="steps__link">
-                    <span>Consider school experience</span>
-                </a>
-            </div>
-            <div class="steps__step">
-                <div class="steps__number"><span>4</span></div>
-                <a href="/steps-to-become-a-teacher#step-4" class="steps__link">
-                    <span>Ways to train</span>
-                </a>
-            </div>
-            <div class="steps__step">
-                <div class="steps__number"><span>5</span></div>
-                <a href="/steps-to-become-a-teacher#step-5" class="steps__link">
-                    <span>Find and apply for teacher training</span>
-                </a>
-            </div>
-          </div>
+      <div class="steps__wrapper">
+        <div class="steps__step">
+            <div class="steps__number"><span>1</span></div>
+            <a href="/steps-to-become-a-teacher#step-1" class="steps__link">
+                <span>Check your qualifications</span>
+            </a>
         </div>
+        <div class="steps__step">
+            <div class="steps__number"><span>2</span></div>
+            <a href="/steps-to-become-a-teacher#step-2" class="steps__link">
+                <span>Find out about teaching and training</span>
+            </a>
+        </div>
+        <div class="steps__step">
+            <div class="steps__number"><span>3</span></div>
+            <a href="/steps-to-become-a-teacher#step-3" class="steps__link">
+                <span>Consider school experience</span>
+            </a>
+        </div>
+        <div class="steps__step">
+            <div class="steps__number"><span>4</span></div>
+            <a href="/steps-to-become-a-teacher#step-4" class="steps__link">
+                <span>Ways to train</span>
+            </a>
+        </div>
+        <div class="steps__step">
+            <div class="steps__number"><span>5</span></div>
+            <a href="/steps-to-become-a-teacher#step-5" class="steps__link">
+                <span>Find and apply for teacher training</span>
+            </a>
+        </div>
+      </div>
     </div>
-</div>
+  </article>
+</section>


### PR DESCRIPTION
Transition the home page to the new semantic layout and update content HTML partials to display correctly under the new layout.

| Desktop      | Mobile |
| ----------- | ----------- |
| ![screencapture-review-get-into-teaching-app-286-london-cloudapps-digital-2021-01-25-11_21_24](https://user-images.githubusercontent.com/29867726/105699661-a2724000-5eff-11eb-841c-7e7260c1bf2a.png)  | ![screencapture-review-get-into-teaching-app-286-london-cloudapps-digital-2021-01-25-11_21_47](https://user-images.githubusercontent.com/29867726/105699901-faa94200-5eff-11eb-8ae3-b0b6965d02ef.png)  |


