### PR TITLE
Checking against wrong ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
 
       - name: Wait for Cypress Tests
         uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-deploy
+        id: wait-for-tests
         with:
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN}}
           checkName: ${{ github.sha }}
@@ -324,7 +324,7 @@ jobs:
           timeoutSeconds: 1800
 
       - name: Check for test failure
-        if: steps.wait-for-build.outputs.conclusion == 'failure'
+        if: steps.wait-for-tests.outputs.conclusion == 'failure'
         run: exit 1
 
   production:


### PR DESCRIPTION
The check for tests routine uses the wrong ID and subsequently will never fail

