### PR TITLE
Better Release Body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,23 +237,27 @@ jobs:
         uses: DFE-Digital/github-actions/GenerateReleaseFromSHA@master
         with:
           sha: ${{github.sha}}
-          
-      - name: Create Temporary Release File
-        if: steps.tag_version.outputs.pr_found == 1
-        run: echo "${{ steps.tag_version.outputs.pr_text }}" > ./temp.md
-      
+            
       - name: Create a GitHub Release
+        id: release
         if: steps.tag_version.outputs.pr_found == 1
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tag_version.outputs.pr_number }}
+          tag_name: steps.tag_version.outputs.pr_number 
           release_name: GiT Content Release ${{ steps.tag_version.outputs.pr_number }}
-          body_path: ./temp.md
           commitish: ${{ github.sha}}
           prerelease: false
           draft: true
+          
+      - name: Copy PR Info to Release
+        if: steps.release.outputs.id      
+        uses: DFE-Digital/github-actions/CopyPRtoRelease@master
+        with:
+          PR_NUMBER:  steps.tag_version.outputs.pr_number
+          RELEASE_ID: steps.release.outputs.id
+          TOKEN: ${{secrets.GITHUB_TOKEN}}          
 
   qa:
     name: Quality Assurance Deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
           
       - name: Create Temporary Release File
         if: steps.tag_version.outputs.pr_found == 1
-        run: echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+        run: echo "${{ steps.tag_version.outputs.pr_text }}" > ./temp.md
       
       - name: Create a GitHub Release
         if: steps.tag_version.outputs.pr_found == 1
@@ -250,7 +250,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag_version.outputs.pr_number }}
           release_name: GiT Content Release ${{ steps.tag_version.outputs.pr_number }}
-          body_path: ${PWD}/temp.md
+          body_path: ./temp.md
           commitish: ${{ github.sha}}
           prerelease: false
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,8 +240,7 @@ jobs:
           
       - name: Create Temporary Release File
         if: steps.tag_version.outputs.pr_found == 1
-        run: 
-            echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
+        run: echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
       
       - name: Create a GitHub Release
         if: steps.tag_version.outputs.pr_found == 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: steps.tag_version.outputs.pr_number 
+          tag_name: ${{ steps.tag_version.outputs.pr_number }} 
           release_name: GiT Content Release ${{ steps.tag_version.outputs.pr_number }}
           commitish: ${{ github.sha}}
           prerelease: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Create Temporary Release File
         if: steps.tag_version.outputs.pr_found == 1
         run: 
-            echo "${{ steps.tag_version.outputs.pr_number }}" > ${PWD}/temp.md
+            echo "${{ steps.tag_version.outputs.pr_text }}" > ${PWD}/temp.md
       
       - name: Create a GitHub Release
         if: steps.tag_version.outputs.pr_found == 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,12 @@ jobs:
         uses: DFE-Digital/github-actions/GenerateReleaseFromSHA@master
         with:
           sha: ${{github.sha}}
-
+          
+      - name: Create Temporary Release File
+        if: steps.tag_version.outputs.pr_found == 1
+        run: 
+            echo "${{ steps.tag_version.outputs.pr_number }}" > ${PWD}/temp.md
+      
       - name: Create a GitHub Release
         if: steps.tag_version.outputs.pr_found == 1
         uses: actions/create-release@v1
@@ -245,8 +250,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.tag_version.outputs.pr_number }}
-          release_name: Release ${{ steps.tag_version.outputs.pr_number }}
-          body: ${{ steps.tag_version.outputs.pr_text }}
+          release_name: GiT Content Release ${{ steps.tag_version.outputs.pr_number }}
+          body_path: ${PWD}/temp.md
           commitish: ${{ github.sha}}
           prerelease: false
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,8 +255,8 @@ jobs:
         if: steps.release.outputs.id      
         uses: DFE-Digital/github-actions/CopyPRtoRelease@master
         with:
-          PR_NUMBER:  steps.tag_version.outputs.pr_number
-          RELEASE_ID: steps.release.outputs.id
+          PR_NUMBER:  ${{ steps.tag_version.outputs.pr_number }}
+          RELEASE_ID: ${{ steps.release.outputs.id }}
           TOKEN: ${{secrets.GITHUB_TOKEN}}          
 
   qa:


### PR DESCRIPTION
### Trello card
https://trello.com/c/Ueda1EDd/640-release-notes-are-only-first-line

### Context
The release is only created with the first line of the PR, I want to improve this to provide the full PR Body

### Changes proposed in this pull request
Create a new GitHub action which copies the data using CURL

### Guidance to review
This will not effect the product
This should not make any effect to the SLACK output, that will come later
This process does not do anything if there is a commit direct to master, this will be fixed when the PR process is fully working.
