### PR TITLE
SKE content updates

### DIFF
--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -67,7 +67,7 @@ There are two main ranges for these (TLR 1 and TLR 2), depending on the category
 
 You'll get more days than people in many other professions. Full-time teachers work for 195 days per year in school.
 
-###Teachers’ Pension Scheme
+### Teachers’ Pension Scheme
 
 The Teachers’ Pension Scheme gives you a regular source of income when you retire. It is:
 

--- a/content/steps-to-become-a-teacher/_check_your_qualifications.md
+++ b/content/steps-to-become-a-teacher/_check_your_qualifications.md
@@ -13,4 +13,3 @@ Here's what you need to do if you:
 * [do not have a degree](/guidance/become-a-teacher-in-england#if-you-do-not-have-a-degree)
 * [have an overseas degree](/international-candidates)
 * [are returning to teach in England](/returning-to-teaching)
-* [want to teach a subject that you didn't study at degree level](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses)

--- a/content/steps-to-become-a-teacher/_check_your_qualifications.md
+++ b/content/steps-to-become-a-teacher/_check_your_qualifications.md
@@ -13,4 +13,4 @@ Here's what you need to do if you:
 * [do not have a degree](/guidance/become-a-teacher-in-england#if-you-do-not-have-a-degree)
 * [have an overseas degree](/international-candidates)
 * [are returning to teach in England](/returning-to-teaching)
-* [want to teach a subject that you didn't study at degree level](/guidance/become-a-teacher-in-england#Subject-knowledge-enhancement-courses)
+* [want to teach a subject that you didn't study at degree level](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses)

--- a/content/steps-to-become-a-teacher/_check_your_qualifications.md
+++ b/content/steps-to-become-a-teacher/_check_your_qualifications.md
@@ -13,3 +13,4 @@ Here's what you need to do if you:
 * [do not have a degree](/guidance/become-a-teacher-in-england#if-you-do-not-have-a-degree)
 * [have an overseas degree](/international-candidates)
 * [are returning to teach in England](/returning-to-teaching)
+* [want to teach a subject that you didn't study at degree level](/guidance/become-a-teacher-in-england#Subject-knowledge-enhancement-courses)

--- a/content/steps-to-become-a-teacher/_find_and_apply_teacher_training.md
+++ b/content/steps-to-become-a-teacher/_find_and_apply_teacher_training.md
@@ -1,6 +1,6 @@
 When you’ve decided the best route for you and what you want to teach, search for a course using the Find postgraduate teacher training service. You can search by: location, provider, subject, study type, and qualification. 
 
-Once you have an idea of the courses available, you can do more research about the individual providers. You can look at their websites, attend one of their events, or look at Ofcom inspection reports for schools.
+Once you have an idea of the courses available, you can do more research about the individual providers. You can look at their websites, attend one of their events, or look at Ofcom inspection reports for schools. There is also guidance if you [want to teach a subject that you didn't study at degree level](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses).
 
 To apply for a course, you will need:
 

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -8,6 +8,7 @@
     - content/ways-to-train/intro
     - content/ways-to-train/things_to_consider
     - content/ways-to-train/things_to_consider_cta
+    -content/ways-to-train/subject-knowledge-enhancement
     - content/ways-to-train/tta_cta_mob
     - content/ways-to-train/pgce
     - content/ways-to-train/school_direct_fee_funded

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -8,7 +8,7 @@
     - content/ways-to-train/intro
     - content/ways-to-train/things_to_consider
     - content/ways-to-train/things_to_consider_cta
-    -content/ways-to-train/subject-knowledge-enhancement
+    -content/ways-to-train/subject_knowledge_enhancement
     - content/ways-to-train/tta_cta_mob
     - content/ways-to-train/pgce
     - content/ways-to-train/school_direct_fee_funded

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -8,7 +8,7 @@
     - content/ways-to-train/intro
     - content/ways-to-train/things_to_consider
     - content/ways-to-train/things_to_consider_cta
-    -content/ways-to-train/subject_knowledge_enhancement
+    - content/ways-to-train/subject_knowledge_enhancement
     - content/ways-to-train/tta_cta_mob
     - content/ways-to-train/pgce
     - content/ways-to-train/school_direct_fee_funded

--- a/content/ways-to-train/_other_ways_to_train.md
+++ b/content/ways-to-train/_other_ways_to_train.md
@@ -8,7 +8,7 @@ If you want a [career change and fancy becoming a teacher](/guidance/become-a-te
 
 ### Researchers in schools
 
-You’ll need (or be about to finish) a doctorate in the [subject you want to teach](/guidance/become-a-teacher-in-england#researchers-in-schools-candidates-with-a-doctorate). You’ll then train over 3 years with a bursary. If you have a lot of relevant work experience you could train and earn a salary.
+You’ll need (or be about to finish) a doctorate in the [subject you want to teach](/guidance/become-a-teacher-in-england#researchers-in-schools-candidates-with-a-doctorate). You’ll then train over 3 years with a bursary. If you have a lot of relevant work experience you could [train and earn a salary](https://thebrilliantclub.org/researchers-in-schools/ris-applicants/ris-training-routes/salary-route/).
 
 ### Postgraduate Early Years Initial Teacher Training (EYITT)
 

--- a/content/ways-to-train/_other_ways_to_train.md
+++ b/content/ways-to-train/_other_ways_to_train.md
@@ -1,3 +1,19 @@
 ## Other ways to train
 
-There are a number of specialised routes into teaching. For more information about ways to train, [read more detailed guidance](/guidance/become-a-teacher-in-england) or talk to us to discuss your options.  
+There are a number of specialised routes into teaching. 
+
+### Career changers
+
+If you want a [career change and fancy becoming a teacher](/guidance/become-a-teacher-in-england#career-changers), you’ll get the chance to use your life and work experience coupled with your passion for your subject to inspire young people. There's plenty of support to get into teaching and make the career change.
+
+### Researchers in schools
+
+You’ll need (or be about to finish) a doctorate in the [subject you want to teach](/guidance/become-a-teacher-in-england#researchers-in-schools-candidates-with-a-doctorate). You’ll then train over 3 years with a bursary. If you have a lot of relevant work experience you could train and earn a salary.
+
+### Postgraduate Early Years Initial Teacher Training (EYITT)
+
+A number of postgraduate Early Years Initial Teacher Training (EYITT) courses are available at university or via a school-led route – all lead to [Early Years Teacher Status (EYTS)](/guidance/become-a-teacher-in-england#teaching-under-fives) on successful completion. EYTS is different to QTS in that you specialise in working with children up to five years old only.
+
+### More information
+
+For more information about ways to train, [read more detailed guidance](/guidance/become-a-teacher-in-england) or talk to us to discuss your options.  

--- a/content/ways-to-train/_subject_knowledge_enhancement.md
+++ b/content/ways-to-train/_subject_knowledge_enhancement.md
@@ -1,0 +1,3 @@
+### Subject knowledge enhancement (SKE)
+
+If you need to top up your knowledge of the subject you want to teach, you could take a [subject knowledge enhancement course (SKE)](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses)

--- a/content/ways-to-train/_things_to_consider.md
+++ b/content/ways-to-train/_things_to_consider.md
@@ -1,5 +1,11 @@
 ### Things to consider
 
+#### Routes into teaching
+
 There are a few ways to train to become a teacher. Each route has different eligibility criteria, end qualifications, and funding options. These will depend on which school or training provider you select and the type of training they provide. 
 
 You may be eligible for funding to pay course fees and support with living costs whilst in training.
+
+#### Subject knowledge enhancement (SKE)
+
+If you need to top up your knowledge of the subject you want to teach, you could take a [subject knowledge enhancement course (SKE)](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses)

--- a/content/ways-to-train/_things_to_consider.md
+++ b/content/ways-to-train/_things_to_consider.md
@@ -1,11 +1,5 @@
 ### Things to consider
 
-#### Routes into teaching
-
 There are a few ways to train to become a teacher. Each route has different eligibility criteria, end qualifications, and funding options. These will depend on which school or training provider you select and the type of training they provide. 
 
 You may be eligible for funding to pay course fees and support with living costs whilst in training.
-
-#### Subject knowledge enhancement (SKE)
-
-If you need to top up your knowledge of the subject you want to teach, you could take a [subject knowledge enhancement course (SKE)](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses)


### PR DESCRIPTION
### Trello card
https://trello.com/c/HMbVUDRh/747-review-content-from-linda-c-about-what-information-presented-at-events-is-now-missing-on-the-website-update-ske-content

### Context
We have a number of more niche routes into teaching buried in the detailed guidance. We also lack clear signposting to SKE content, which is a common user question.

This PR aims to address both by trailing SKEs and niche routes on Ways to Train, as well as a link in Steps to Become.

### Changes proposed in this pull request

### Guidance to review

Is this too much content on the Ways to Train?
Does the SKE content below the CTA button at top of ways to train page work? It looks a little peculiar to me.
