### PR TITLE
Updated with new Maintenance Loan values for 21/22

### DIFF
--- a/content/funding-your-training/_tuition-fee-and-maintenance-loans.md
+++ b/content/funding-your-training/_tuition-fee-and-maintenance-loans.md
@@ -4,6 +4,6 @@ You can apply for a tuition fee loan to pay for your training so you don't need 
 
 Even if a bursary or scholarship is available for your course, you can get student finance to cover your fees and help with your living costs. You can apply for a tuition fee and/or a maintenance loan even if you already have a student loan.
 
-You can apply for a tuition fee loan of up to £9,250 to cover the full cost of your course fees and a maintenance loan of up to £12,010 to help with your living costs.
+You can apply for a tuition fee loan of up to £9,250 to cover the full cost of your course fees and a maintenance loan of up to £12,382 to help with your living costs.
 
 You will only have to make repayments when you're earning. Your repayments will not increase if you already have a student loan and take a loan out for teacher training.


### PR DESCRIPTION
### Trello card
N/A - adhoc change
### Context
The latest Maintenance Loan value is now £12,382 for 21/22. So amending copy to reflect this from £12,010.
### Changes proposed in this pull request
£12,010 --> £12,382 site-wide.
### Guidance to review
I've checked the whole website using ctrl-f, this is the only instance.
