### PR TITLE
Updating branding for TTAs (all CAPS)

### DIFF
--- a/content/guidance/become-a-teacher-in-england.md
+++ b/content/guidance/become-a-teacher-in-england.md
@@ -629,7 +629,7 @@ You should use this section to showcase your motivation, commitment and teaching
 
 Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.
 
-To get help with personal statements from a teacher training adviser, [use the Get an adviser service](/tta-service).
+To get help with personal statements from a Teacher Training Adviser, [use the Get an adviser service](/tta-service).
 
 You don't have to cover everything in this list, but suggested topics
 include:

--- a/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.md
+++ b/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.md
@@ -9,8 +9,8 @@ Events give you a chance to talk to real teachers, experts, and training provide
   <a href="/events" class="button">Attend an event</a>
 </p> 
 
-### Get advice from a teacher training adviser 
-All our teacher training advisers are experienced teachers who can support you through the whole process and offer you one-to-one advice. 
+### Get advice from a Teacher Training Adviser 
+All our Teacher Training Advisers are experienced teachers who can support you through the whole process and offer you one-to-one advice. 
 
 This is a free service and your adviser will be there to support you throughout the whole process of becoming a teacher. 
 

--- a/content/three-things-to-help-you-get-into-teaching.md
+++ b/content/three-things-to-help-you-get-into-teaching.md
@@ -3,7 +3,7 @@
   image: /assets/images/hero-home-dt.jpg
   layout: layouts/campaigns/landing_page_with_hero_nav
   hero_nav:
-    Get free one-to-one advice from a teacher training adviser: "#get-free-one-to-one-advice-from-a-teacher-training-adviser"
+    Get free one-to-one advice from a Teacher Training Adviser: "#get-free-one-to-one-advice-from-a-teacher-training-adviser"
     Speak to current teachers at a teaching event: "#speak-to-current-teachers-at-a-teaching-event"
     Receive personalised email updates and tips: "#receive-personalised-email-updates-and-tips"
   keywords:
@@ -20,10 +20,10 @@
 
 <div id="get-free-one-to-one-advice-from-a-teacher-training-adviser" class="numbered-heading">
   <span class="pink-rotated-number">1</span>
-  <h2>Get free one-to-one advice from a teacher training adviser</h2>
+  <h2>Get free one-to-one advice from a Teacher Training Adviser</h2>
 </div>
 
-All our teacher training advisers are experienced teachers who can provide you with support through the whole process of preparing and applying for teacher training.
+All our Teacher Training Advisers are experienced teachers who can provide you with support through the whole process of preparing and applying for teacher training.
 
 Advisers can:
 

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -20,10 +20,10 @@
     - content/ways-to-train/other_ways_to_train_cta
   right_column:
     ctas:
-      - title: Get support from a teacher training adviser
+      - title: Get support from a Teacher Training Adviser
         text: |
-         If you’re not sure which would be the best way to train for you, you can get personalised support from a teacher training adviser.
-        link_text: "Get a teaching training adviser"
+         If you’re not sure which would be the best way to train for you, you can get personalised support from a Teacher Training Adviser.
+        link_text: "Get a Teaching Training Adviser"
         link_target: "/tta-service"
         icon: "icon-person"
         hide_on_mobile: Yes

--- a/content/ways-to-train/_tta_cta_mob.html.erb
+++ b/content/ways-to-train/_tta_cta_mob.html.erb
@@ -1,7 +1,7 @@
 <%= render CallsToAction::SimpleComponent.new(
-  title: "Get support from a teacher training adviser",
-  text: "If you’re not sure which would be the best way to train for you, you can get personalised support from a teacher training adviser.",
-  link_text: "Get a teaching training adviser",
+  title: "Get support from a Teacher Training Adviser",
+  text: "If you’re not sure which would be the best way to train for you, you can get personalised support from a Teacher Training Adviser.",
+  link_text: "Get a Teaching Training Adviser",
   link_target: "/tta-service",
   icon: "icon-person",
   hide_on_desktop: true


### PR DESCRIPTION
### Trello card
N/A
### Context
Enforcing capitalisation of Teacher Training Adviser throughout the site.
### Changes proposed in this pull request
teacher training adviser --> Teacher Training Adviser

