### PR TITLE
Replaced reference to Online events with Online Q&As

### DIFF
--- a/content/international-candidates.md
+++ b/content/international-candidates.md
@@ -4,7 +4,7 @@ image: "/assets/images/international-dt.jpg"
 backlink: "../../"
 right_column:
   ctas:
-    - title: Online events
+    - title: Online Q&As
       text: |
         Come to an online event where you can ask advice from our panel of
         teaching experts about coming to teach in England.


### PR DESCRIPTION
### Trello card

https://trello.com/c/qFdcdHa2

### Context

We now refer to events from the online events category as Online Q&As

### Changes proposed in this pull request

1. Updated the title



