### PR TITLE
Change salary ranges to mini tables

### DIFF
--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -28,7 +28,7 @@ Schools develop their own pay policies to attract and retain teachers that have 
 
 ## Qualified teachers
 
-As a newly qualified teacher you could earn between £25,714 and £32,157 depending on where you teach.
+As a newly qualified teacher you could earn between £25,714 and £50,953 depending on where you teach.
 
 As you progress in your teaching career, it's possible to move up through these pay ranges:
 

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -32,10 +32,12 @@ As a newly qualified teacher you could earn between £25,714 and £32,157 depend
 
 As you progress in your teaching career, it's possible to move up through these pay ranges:
 
-* England and Wales (excluding London and fringes) - between £25,714 and £41,604
-* London fringe - between £26,948 and £42,780
-* Outer London - between £29,915 and £45,766
-* Inner London - between £32,157 and £50,935
+| Area                          | Minimum | Maximum |
+| -------                       | -----   | -----   |
+| Inner London                  | £32,157 | £50,953 |
+| Outer London                  | £29,915 | £45,766 |
+| London fringe                 | £26,948 | £42,780 |
+| The rest of England and Wales | £25,714 | £41.604 |
 
 ## Leading practitioners
 
@@ -43,28 +45,35 @@ A Leading Practitioner is an excellent and highly skilled teacher who consistent
 
 In this role you could earn between £42,402 and £72,480 depending on where you teach.
 
-* England and Wales (excluding London and fringes) - between £42,402 and £64,461
-* London fringe - between £43,570 and £65,631
-* Outer London - between £45,766 and £67,828
-* Inner London - between £50,415 and £72,480
+| Area                          | Minimum | Maximum |
+| -------                       | -----   | -----   |
+| Inner London                  | £50,415 | £72,480 |
+| Outer London                  | £45,766 | £67,828 |
+| London fringe                 | £43,570 | £65,631 |
+| The rest of England and Wales | £42,402 | £64,461 |
 
 ## Headteachers
 
 Headteachers lead, motivate and manage staff. In this role you will earn between £47,735 to £125,098 depending on where you teach.
 
-* England and Wales (excluding London and fringes) - between £47,735 and £117,197
-* London fringe - between £48,901 and £118,356
-* Outer London - between £51,082 and £120,513
-* Inner London - between £55,715 and £125,098
+| Area                          | Minimum | Maximum  |
+| -------                       | -----   | -----    |
+| Inner London                  | £55,715 | £125,098 |
+| Outer London                  | £51,082 | £120,513 |
+| London fringe                 | £48,901 | £118,356 |
+| The rest of England and Wales | £47,735 | £117,197 |
+
 
 ## Unqualified teachers
 
 As an unqualified teacher you could earn between £18,169 and £33,410 depending on where you teach and your level of experience.
 
-* England and Wales (excluding London and fringes) - between £18,169 and £28,735
-* London fringe - between £19,363 and £29,924
-* Outer London - between £21,582 and £32,151
-* Inner London - between £22,849 and £33,410
+| Area                          | Minimum | Maximum |
+| -------                       | -----   | -----   |
+| Inner London                  | £22,849 | £33,410 |
+| Outer London                  | £21,582 | £32,151 |
+| London fringe                 | £19,363 | £29,924 |
+| The rest of England and Wales | £18,169 | £28,735 |
 
 ## Teacher benefits
 
@@ -74,8 +83,10 @@ If you take on extra ongoing responsibilities in your role, you could get a sala
 
 There are two main ranges for these (TLR 1 and TLR 2), depending on the category your duties come under:
 
-* TLR 1 £8,291 - £14,030
-* TLR 2 £2,873 - £7,017
+| Level   | Minimum | Maximum |
+| ------- | -----   | -----   |
+| TLR 1   | £8,291  | £14,030 |
+| TLR 2   | £2,873  | £7,017  |
 
 ### Holidays
 

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -28,7 +28,7 @@ Schools develop their own pay policies to attract and retain teachers that have 
 
 ## Qualified teachers
 
-As a newly qualified teacher you could earn between £25,714 and £50,953 depending on where you teach.
+As a newly qualified teacher you could earn between £25,714 and £32,157 depending on where you teach.
 
 As you progress in your teaching career, it's possible to move up through these pay ranges:
 


### PR DESCRIPTION
The pay range lists are quite wordy and aren't easy to quickly scan. Moving them to a table and inverting the order allows us to simplify the language and make the appearance clearer overall.

Also add a fix to one of the range descriptions that wasn't consistent with the others.