### PR TITLE
Add guidance for international applicants

### DIFF
--- a/config/frontmatter.yml
+++ b/config/frontmatter.yml
@@ -3,6 +3,7 @@ acronyms:
   NQT: Newly Qualified Teacher
   DSA: Disabled Students’ Allowance
   EU: European Union
+  EEA: European Economic Area
   DfE: Department for Education
   TLR: Teaching and learning responsibility
   SCITT: school-centred initial teacher training

--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -137,7 +137,10 @@ If you live in [Wales](http://www.studentfinancewales.co.uk/), [Scotland](http:/
 
 Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or on the [Isle of Man](https://www.gov.im/student-grants).
 
-If you’re from within the EEA or Switzerland and are starting a teacher training course in the academic year 2021/22, you [may get a bursary or scholarship, and student finance](/guidance/financial-support-for-international-applicants#applicants-from-countries-within-the-european-economic-area-eea-or-switzerland).
+If you are an applicant from outside the UK, read our [guidance on financial help for international applicants](/guidance/financial-support-for-international-applicants#applicants-from-countries-within-the-european-economic-area-eea-or-switzerland) to check:
+
+* the types of financial help available
+* whether you meet the eligibility requirements
 
 $international-candidates$
 

--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -128,13 +128,14 @@ $financial-support-for-teacher-training$
 
 ## Applying for funding if you come from outside England
 
-Whether you’re a home student (living in Wales, Scotland or Northern Ireland), an EU student or a student from outside the EU, you may still be eligible for funding to train to teach.
+If you live outside England you may still be eligible for funding to train to teach via:
+
+* a [bursary or scholarship](#bursaries-and-scholarships)
+* [student finance](#tuition-fee-and-maintenance-loans)
 
 If you live in [Wales](http://www.studentfinancewales.co.uk/), [Scotland](http://www.saas.gov.uk/) or [Northern Ireland](http://www.studentfinanceni.co.uk/) you’ll need to contact your country’s student finance body.
 
 Contact the education authority if you live in the Channel Islands ([Jersey](https://www.gov.je/Working/Careers/16To19YearOlds/EnteringHigherEducation/FinancingHigherEducationCourses/FundingDegreeProfessionalQualifications/Pages/index.aspx) and [Guernsey](https://www.gov.gg/article/152744/Policies)) or on the [Isle of Man](https://www.gov.im/student-grants).
-
-You could get a bursary or scholarship, student finance and extra funding to train to teach.
 
 If you’re from within the EEA or Switzerland and are starting a teacher training course in the academic year 2021/22, you [may get a bursary or scholarship, and student finance](/guidance/financial-support-for-international-applicants#applicants-from-countries-within-the-european-economic-area-eea-or-switzerland).
 

--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -136,7 +136,7 @@ Contact the education authority if you live in the Channel Islands ([Jersey](htt
 
 You could get a bursary or scholarship, student finance and extra funding to train to teach.
 
-If you’re an EU national starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance.
+If you’re from within the EEA or Switzerland and are starting a teacher training course in the academic year 2021/22, you [may get a bursary or scholarship, and student finance](/guidance/financial-support-for-international-applicants#applicants-from-countries-within-the-european-economic-area-eea-or-switzerland).
 
 $international-candidates$
 

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -38,13 +38,13 @@ Types of financial help:
 ### Tuition fee loan
 
 Your tuition fees are paid, with the money going directly to your teacher
-training provider. This is a loan you have to pay back, but you’ll only start
+training provider. This is a loan you have to pay back, but you'll only start
 your repayments when your income is over £27,295 per year.
 
 ### Maintenance loan
 
 Money is paid directly into your bank account to help with living costs. This
-is a loan you have to pay back, but you’ll only start your repayments when your
+is a loan you have to pay back, but you'll only start your repayments when your
 income is over £27,295 per year.
 
 ### Home fee status
@@ -145,7 +145,7 @@ training bursary or scholarship.
 
 ## How to apply
 
-You can apply for financial support when you’ve accepted your place on
+You can apply for financial support when you've accepted your place on
 an unsalaried teacher training course.
 
 Apply to [Student Finance England](https://www.gov.uk/student-finance) for:
@@ -156,7 +156,7 @@ Apply to [Student Finance England](https://www.gov.uk/student-finance) for:
 
 Talk to your training provider about:
 
-  - home fee status (they are likely to offer this if you’ve been awarded a tuition fee loan)
+  - home fee status (they are likely to offer this if you've been awarded a tuition fee loan)
   - a [bursary or scholarship](/funding-your-training#bursaries-and-scholarships)
 
 ## More information

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -13,8 +13,8 @@ or contact [Student Finance England](https://www.gov.uk/contact-student-finance-
 
 ## Applicants from countries outside the European Economic Area (EEA) or Switzerland
 
-If you are an applicant from these countries, you are unlikely to be
-eligible for financial support.
+If you are an applicant from outside [the EEA](https://www.gov.uk/eu-eea) or
+Switzerland, you are unlikely to be eligible for financial support.
 
 In order to be eligible for student support, you must usually have
 'settled' status and have been living in the UK throughout the three

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -22,7 +22,7 @@ years immediately before the start of your course.
 
 For more information, contact [Student Finance England](https://www.gov.uk/contact-student-finance-england).
 
-## Applicants from countries within the [European Economic Area (EEA) or Switzerland
+## Applicants from countries within the European Economic Area (EEA) or Switzerland
 
 The EEA includes EU countries, plus Iceland, Liechtenstein and Norway.
 

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -159,7 +159,7 @@ Apply to [Student Finance England](https://www.gov.uk/student-finance) for:
 Talk to your training provider about:
 
   - home fee status (they are likely to offer this if you’ve been awarded a tuition fee loan)
-  - a [bursary](https://beta-getintoteaching.education.gov.uk/funding-your-training) or scholarship
+  - a [bursary or scholarship](https://beta-getintoteaching.education.gov.uk/funding-your-training)
 
 ## More information
 

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -166,8 +166,8 @@ Talk to your training provider about:
 You can find more detailed information about tuition fee loans and
 maintenance loans here:
 
-  - Guidance for EU Students studying in the UK
-  - New eligibility rules for home fee status and student finance for 2021/22
+  - [Guidance for EU Students studying in the UK](https://www.gov.uk/guidance/studying-in-the-uk-guidance-for-eu-students)
+  - [New eligibility rules for home fee status and student finance for 2021/22](https://www.gov.uk/government/publications/student-finance-eligibility-2021-to-2022-academic-year)
   - [Access to student finance FAQs](https://dfemedia.blog.gov.uk/access-to-student-finance-from-academic-year-2021-22-faqs/)
 
 You can [contact Student Finance England directly](https://www.gov.uk/contact-student-finance-england) –

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -1,8 +1,8 @@
 ---
 title: |-
   UK government financial support for international applicants to
-  unsalaried teacher training courses in England (academic year 2021 to
-  2022)
+  unsalaried teacher training courses in England 
+title_caption: Academic year 2021 to 2022
 ---
 
 You may be eligible for financial support if you meet the requirements

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -5,6 +5,11 @@ title: |-
 title_caption: Academic year 2021 to 2022
 ---
 
+### Contents
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
+
 You may be eligible for financial support if you meet the requirements
 explained on this page. This is an overview of the rules, and exceptions
 may apply in certain circumstances. For help and advice, review the

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -72,7 +72,7 @@ maintenance loan if you:
   - have settled status under the [EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families),
     and
   - have been resident in the UK throughout the 3 years before the
-    start of your course.
+    start of your course
 
 Alternatively, you may be able to get both a tuition fee loan and a
 maintenance loan if you:

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -1,0 +1,176 @@
+---
+title: |-
+  UK government financial support for international applicants to
+  unsalaried teacher training courses in England (academic year 2021 to
+  2022)
+---
+
+You may be eligible for financial support if you meet the requirements
+explained on this page. This is an overview of the rules, and exceptions
+may apply in certain circumstances. For help and advice, review the
+information at the GOV.UK pages listed at [more information](#more-information)
+or contact [Student Finance England](https://www.gov.uk/contact-student-finance-england).
+
+## Applicants from countries outside the European Economic Area (EEA) or Switzerland
+
+If you are an applicant from these countries, you are unlikely to be
+eligible for financial support.
+
+In order to be eligible for student support, you must usually have
+'settled' status and have been living in the UK throughout the three
+years immediately before the start of your course.
+
+For more information, contact [Student Finance England](https://www.gov.uk/contact-student-finance-england).
+
+## Applicants from countries within the [European Economic Area (EEA) or Switzerland
+
+The EEA includes EU countries, plus Iceland, Liechtenstein and Norway.
+
+If you have [settled or pre-settled status](https://www.gov.uk/settled-status-eu-citizens-families/what-settled-and-presettled-status-means)
+under the EU Settlement Scheme, you may be able to get some or all of
+the following types of financial help with your living costs or teacher
+training course fees ('tuition fees').
+
+Special provisions apply to [Irish citizens](#irish-citizens).
+
+Types of financial help:
+
+### Tuition fee loan
+
+Your tuition fees are paid, with the money going directly to your teacher
+training provider. This is a loan you have to pay back, but you’ll only start
+your repayments when your income is over £27,295 per year.
+
+### Maintenance loan
+
+Money is paid directly into your bank account to help with living costs. This
+is a loan you have to pay back, but you’ll only start your repayments when your
+income is over £27,295 per year.
+
+### Home fee status
+
+You are charged tuition fees at the domestic rate, which is usually lower than
+the rate charged to international students.
+
+### Extra financial support
+
+You can apply for extra help if you have a disability, or children or other
+people to care for. You do not have to pay this money back.
+
+### Teacher training bursary or scholarship
+
+Money is paid directly into your bank account and you can use this as you wish.
+You do not have to pay this money back.
+
+## Check what support is available
+
+### Tuition fee and maintenance loans
+
+You will generally be eligible for both a tuition fee loan and a
+maintenance loan if you:
+
+  - have settled status under the [EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families),
+    and
+  - have been resident in the UK throughout the 3 years before the
+    start of your course.
+
+Alternatively, you may be able to get both a tuition fee loan and a
+maintenance loan if you:
+
+  - have settled or pre-settled status under the EU Settlement Scheme,
+    and
+  - have been resident in the UK, EEA or Switzerland throughout the 3
+    years before the start of your course, and
+  - are an EEA/Swiss worker or a family member of one
+
+A '[worker](https://www.ukcisa.org.uk/information--advice/fees-and-money/government-student-support#layer-6212)'
+is someone who is employed or self-employed in the UK.
+
+A '[family member](https://www.ukcisa.org.uk/information--advice/fees-and-money/government-student-support#layer-6212)'
+is a spouse or civil partner, child and, sometimes, parent or grandparent.
+
+### Tuition fee loan without maintenance loan
+
+If you are not eligible for both a tuition fee loan and maintenance loan
+then you may be able to get a tuition fee loan without a maintenance
+loan if you:
+
+  - are an EU national with settled or pre-settled status under the EU
+    Settlement Scheme, and
+  - have been resident in the UK, EEA or Switzerland throughout the 3
+    years before the start of your course
+
+More detailed guidance is available for [EEA and Swiss students about
+eligibility for tuition fee and maintenance loans in the academic year 2021 to
+2022](https://www.gov.uk/guidance/studying-in-the-uk-guidance-for-eu-students#changes-to-funding-from-the-2021-to-2022-academic-year).
+
+### Irish citizens
+
+Special provisions apply to Irish citizens. If you are an Irish citizen
+then you do not need to have settled or pre-settled status under the EU
+Settlement Scheme as you already have settled status in the UK.
+
+You will generally be eligible for a [tuition fee loan](#tuition-fee-loan) and a
+[maintenance loan](#maintenance-loan) if you:
+
+  - are an Irish citizen, and
+  - have been resident in the UK throughout the 3 years immediately before the
+    start of your course
+
+You will generally be eligible for a [tuition fee loan](#tuition-fee-loan) only if you:
+
+  - are an Irish citizen, and
+  - have been resident in Ireland, or Ireland and the UK, throughout
+    the 3 years before the start of your course
+
+### Home fee status
+
+If you meet the requirements for a tuition fee loan, or tuition fee and
+maintenance loan, we anticipate that providers will award you home fee
+status.
+
+### Extra financial support for trainees with particular needs
+
+If you have a disability, children or adult dependents, and you are
+eligible for a tuition fee loan and maintenance loan, you may be able to
+apply for extra help. [Learn more about extra
+financial
+support](https://beta-getintoteaching.education.gov.uk/funding-your-training).
+
+### Teacher training bursary or scholarship
+
+If you meet the eligibility requirements for a tuition fee loan, or
+tuition fee and maintenance loan, you may also be eligible for a teacher
+training bursary or scholarship.
+
+[Bursaries and scholarships are only available in certain subjects](https://beta-getintoteaching.education.gov.uk/funding-your-training).
+
+## How to apply
+
+You can apply for financial support when you’ve accepted your place on
+an unsalaried teacher training course.
+
+Apply to [Student Finance England](https://www.gov.uk/student-finance) for:
+
+  - tuition fee loans
+  - maintenance loans
+  - extra help if you have a disability, children or adult dependents
+
+Talk to your training provider about:
+
+  - home fee status (they are likely to offer this if you’ve been awarded a tuition fee loan)
+  - a [bursary](https://beta-getintoteaching.education.gov.uk/funding-your-training) or scholarship
+
+## More information
+
+You can find more detailed information about tuition fee loans and
+maintenance loans here:
+
+  - Guidance for EU Students studying in the UK
+  - New eligibility rules for home fee status and student finance for 2021/22
+  - [Access to student finance FAQs](https://dfemedia.blog.gov.uk/access-to-student-finance-from-academic-year-2021-22-faqs/)
+
+You can [contact Student Finance England directly](https://www.gov.uk/contact-student-finance-england) –
+they have dedicated phone lines for EU students and for EEA citizens working in the UK.
+
+You can also contact the [UK Council for International Student Affairs](https://www.ukcisa.org.uk/About-UKCISA) for advice.

--- a/content/guidance/financial-support-for-international-applicants.md
+++ b/content/guidance/financial-support-for-international-applicants.md
@@ -133,9 +133,7 @@ status.
 
 If you have a disability, children or adult dependents, and you are
 eligible for a tuition fee loan and maintenance loan, you may be able to
-apply for extra help. [Learn more about extra
-financial
-support](https://beta-getintoteaching.education.gov.uk/funding-your-training).
+apply for extra help. [Learn more about extra financial support](/funding-your-training).
 
 ### Teacher training bursary or scholarship
 
@@ -143,7 +141,7 @@ If you meet the eligibility requirements for a tuition fee loan, or
 tuition fee and maintenance loan, you may also be eligible for a teacher
 training bursary or scholarship.
 
-[Bursaries and scholarships are only available in certain subjects](https://beta-getintoteaching.education.gov.uk/funding-your-training).
+[Bursaries and scholarships are only available in certain subjects](/funding-your-training#bursaries-and-scholarships).
 
 ## How to apply
 
@@ -159,7 +157,7 @@ Apply to [Student Finance England](https://www.gov.uk/student-finance) for:
 Talk to your training provider about:
 
   - home fee status (they are likely to offer this if you’ve been awarded a tuition fee loan)
-  - a [bursary or scholarship](https://beta-getintoteaching.education.gov.uk/funding-your-training)
+  - a [bursary or scholarship](/funding-your-training#bursaries-and-scholarships)
 
 ## More information
 

--- a/content/international-candidates.md
+++ b/content/international-candidates.md
@@ -106,7 +106,11 @@ You can browse available teaching jobs in England using the UK government’s [T
 
 ### Funding
 
-If you’re an EU national starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance on a similar basis to domestic students if you have settled or pre-settled status under the [EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families), and meet the usual residence requirements.
+If you're an applicant from the EEA or Switzerland starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance on a similar basis to domestic students if you have settled or pre-settled status under the EU Settlement Scheme, and meet the usual residence requirements. [Find out more about financial support for international applicants](/guidance/financial-support-for-international-applicants).
+
+<!-- what are the 'usual residence requirements'? -->
+<!-- "bursary or scholarship, and student finance" sounds clunky -->
+<!-- can we link some actual text rather than appending on a 'find out more' sentence? -->
 
 ### What you’ll need
 

--- a/content/international-candidates.md
+++ b/content/international-candidates.md
@@ -106,13 +106,10 @@ You can browse available teaching jobs in England using the UK government’s [T
 
 ### Funding
 
-You may be entitled to a [bursary or scholarship](/funding-your-training#bursaries-and-scholarships) or
-[student finance](/funding-your-training#tuition-fee-and-maintenance-loans) if you:
+Read our [guidance on financial help for international applicants](/guidance/financial-support-for-international-applicants) to check:
 
-* are starting a teacher training course in the academic year 2021/22
-* are from the EEA or Switzerland
-* have settled or [pre-settled status under the EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families)
-* meet the [required residence requirements](/guidance/financial-support-for-international-applicants)
+* the types of financial help available
+* whether you meet the eligibility requirements
 
 ### What you’ll need
 

--- a/content/international-candidates.md
+++ b/content/international-candidates.md
@@ -106,11 +106,13 @@ You can browse available teaching jobs in England using the UK government’s [T
 
 ### Funding
 
-If you're an applicant from the EEA or Switzerland starting a teacher training course in the academic year 2021/22, you may get a bursary or scholarship, and student finance on a similar basis to domestic students if you have settled or pre-settled status under the EU Settlement Scheme, and meet the usual residence requirements. [Find out more about financial support for international applicants](/guidance/financial-support-for-international-applicants).
+You may be entitled to a [bursary or scholarship](/funding-your-training#bursaries-and-scholarships) or
+[student finance](/funding-your-training#tuition-fee-and-maintenance-loans) if you:
 
-<!-- what are the 'usual residence requirements'? -->
-<!-- "bursary or scholarship, and student finance" sounds clunky -->
-<!-- can we link some actual text rather than appending on a 'find out more' sentence? -->
+* are starting a teacher training course in the academic year 2021/22
+* are from the EEA or Switzerland
+* have settled or [pre-settled status under the EU Settlement Scheme](https://www.gov.uk/settled-status-eu-citizens-families)
+* meet the [required residence requirements](/guidance/financial-support-for-international-applicants)
 
 ### What you’ll need
 


### PR DESCRIPTION
This is a direct import of content provided to us. It looks like it needs a few tweaks before it's published.


## Page balance

The heading is _rather long_ and dominates the page. It could be more succinct.

![Screenshot from 2021-03-01 10-12-16](https://user-images.githubusercontent.com/128088/109483409-19f33c00-7a77-11eb-92b9-435aa5110c9f.png)

## Linking from within headers

This should be avoided, the collective definition of the EEA/Switzerland should probably be defined on the page.

![Screenshot from 2021-03-01 10-16-24](https://user-images.githubusercontent.com/128088/109483536-44dd9000-7a77-11eb-8a5e-166067bbd3f9.png)

## Remove connecting words from lists

Typically we avoid this and each list entry is a standalone statement that follows on from the sentence preceding the list. Here's an example excerpt (note the `, and`):

```markdown
  - have settled or pre-settled status under the EU Settlement Scheme,
    and
  - have been resident in the UK, EEA or Switzerland throughout the 3
    years before the start of your course, and
  - are an EEA/Swiss worker or a family member of one
```