### PR TITLE
Run the External Links checker every morning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
           tags: |
                  ${{ steps.sha.outputs.image }}
                  ${{ steps.sha.outputs.local }}
+                 latest
           push: true
           build-args: |
                       CONTENT_SHA=${{ steps.sha.outputs.short }}

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy
+
+on:
+  schedule:
+    - cron: "35 6 * * *"
+
+jobs:
+  linkchecker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: Development
+    steps:
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'SLACK-WEBHOOK'
+
+      - name: Check for broken links
+        run: |
+          docker run -t --rm -e RAILS_ENV=test \
+            ${{ env.DOCKERHUB_REPOSITORY }}:latest \
+            rspec --format documentation -t onschedule spec/features/external_links_spec.rb
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: ${{env.SLACK_ERROR}}
+          SLACK_MESSAGE: Broken links found on Get into Teaching
+          SLACK_TITLE: Broken links on GiT ${{ github.workflow }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Link Checker
 
 on:
   schedule:


### PR DESCRIPTION
### Trello card

https://trello.com/c/pUu6GogQ

### Context

We should run the external links checker on a scheduled basis so that we discover when we have broken links.

### Changes proposed in this pull request

1. Tag builds on `master` as `:latest` so which know which is the most recent build
2. Scheduled check using `:latest` for 6:35 so we see the results early in the day, but its not at peak
times for GitHubs actions - they suggest using an 'odd' time rather than on the
hour.

