### PR TITLE
Bring the daily External Links check back in

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,0 +1,48 @@
+name: Link Checker
+
+on:
+  schedule:
+    - cron: "35 6 * * *"
+
+jobs:
+  linkchecker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: Development
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: set-up-environment
+        uses: DFE-Digital/github-actions/set-up-environment@master
+
+      - uses: Azure/login@v1
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id:   azSecret
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'SLACK-WEBHOOK'
+
+      - name: Determine latest master build
+        id: sha
+        run: echo ::set-output name=short::$(cat .git/refs/heads/master | cut -c -7)
+
+      - name: Check for broken links
+        run: |
+          docker run -t --rm -e RAILS_ENV=test \
+            ${{ env.DOCKERHUB_REPOSITORY }}:sha-${{ steps.sha.outputs.short }} \
+            rspec --format documentation -t onschedule spec/features/external_links_spec.rb
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_COLOR: ${{env.SLACK_ERROR}}
+          SLACK_MESSAGE: Broken links found on Get into Teaching
+          SLACK_TITLE: Broken links on GiT ${{ github.workflow }}
+          SLACK_WEBHOOK: ${{ steps.azSecret.outputs.SLACK-WEBHOOK }}


### PR DESCRIPTION
Second attempt - reverts DFE-Digital/get-into-teaching-content#361

Now checks out master branch, and uses the latest sha from the master branch to determine the image to run the check from