### PR TITLE
Add name to the mailinglist signup link

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -10,7 +10,7 @@
   lid_pixel_event: "Homepage"
   subtitle: "Get information and support to help you become a teacher"
   subtitle_button: "Sign up for updates"
-  subtitle_link: "/mailinglist/signup"
+  subtitle_link: "/mailinglist/signup/name"
   image: "media/images/hero-home-dt.jpg"
   backlink: "/"
   content:

--- a/content/home/_directory.html.erb
+++ b/content/home/_directory.html.erb
@@ -35,7 +35,7 @@
     <ul>
       <li><a href="/tta-service">Get an adviser</a></li>
       <li><a href="/events">Go to an event</a></li>
-      <li><a href="/mailinglist/signup">Sign up for personalised updates</a></li>
+      <li><a href="/mailinglist/signup/name">Sign up for personalised updates</a></li>
     </ul>
   <% end %>
 </section>

--- a/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.html.erb
+++ b/content/steps-to-become-a-teacher/_find_out_about_teaching_and_training.html.erb
@@ -45,7 +45,7 @@
       a career in teaching could take you, and how to take your next steps. 
     </p>
 
-    <a href="/mailinglist/signup" class="button button--smaller">Sign up for personalised updates</a>
+    <a href="/mailinglist/signup/name" class="button button--smaller">Sign up for personalised updates</a>
   </section>
 
   <section>

--- a/content/three-things-to-help-you-get-into-teaching.md
+++ b/content/three-things-to-help-you-get-into-teaching.md
@@ -65,4 +65,4 @@ Get personalised information straight to your inbox with everything you need to 
 * how to take your next step to becoming a teacher
 * where your teaching career could take you
 
-<a class="button" href="/mailinglist/signup"><span>Get email updates</span></a>
+<a class="button" href="/mailinglist/signup/name"><span>Get email updates</span></a>


### PR DESCRIPTION
### Trello card

https://trello.com/c/H2lwqz5c/1402-epic-seo-preparation

### Context and changes.

Changing the links from `/mailinglist/signup` to `/mailinglist/signup/name` prevents us from linking to a route that immediately 301's the user, something that can affect our SEO.