### PR TITLE
Update Uni Hull AO details

### DIFF
--- a/content/assessment-only-providers.md
+++ b/content/assessment-only-providers.md
@@ -443,9 +443,9 @@ providers:
     telephone: '01977 657604'
     email: ytca@minsthorpe.cc
   - header: University of Hull
+    name: Initial Teacher Education Partners
     link: https://www.hull.ac.uk
-    telephone: '01482 466530'
-    email: FACE-admissions@hull.ac.uk
+    email: FACE-ITEPartners@hull.ac.uk
   - header: Yorkshire and Humber Teacher Training
     link: https://www.yhtt.co.uk
     name: Chris Fletcher


### PR DESCRIPTION
We've received updated details for Hull Uni for Assessment Only. These have been updated in this PR.



