### PR TITLE
Remove keywords from finance guidance - not linked to

### DIFF
--- a/content/funding-your-training.md
+++ b/content/funding-your-training.md
@@ -70,6 +70,19 @@
     - Guernsey
     - Jersey
     - Isle of Man
+    - Undergraduate
+    - Troops to Teachers
+    - Army
+    - Air Force
+    - Navy
+    - Parents
+    - Parents’ Learning Allowance
+    - Childcare
+    - Childcare Grant
+    - Adult Dependants’ Grant
+    - Disabled students
+    - Disabled Students’ Allowances
+    
 ---
 
 

--- a/content/guidance/become-a-teacher-in-england.md
+++ b/content/guidance/become-a-teacher-in-england.md
@@ -146,7 +146,7 @@ check if you intend to teach students under 18.
 
 ## Financial support
 
-If you need further information on financial support options, such as bursaries, scholarships and extra support for parents, carers or people with disabilities, this is available on the [financial support for teaching training guidance page](/guidance/financial-support-for-teacher-training).
+If you need further information on financial support options, such as bursaries, scholarships and extra support for parents, carers or people with disabilities, this is available on the [financial support for teaching training guidance page](/funding-your-training).
 
 ## Ways to train
 

--- a/content/guidance/financial-support-for-teacher-training.md
+++ b/content/guidance/financial-support-for-teacher-training.md
@@ -6,24 +6,6 @@ related_content:
   Teacher training funding: https://www.gov.uk/teacher-training-funding
   "Early years initial teacher training: 2020 to 2021 funding guidance": https://www.gov.uk/guidance/early-years-initial-teacher-training-2020-to-2021-funding-guidance
   "Qualified teacher status (QTS): qualify to teach in England": https://www.gov.uk/guidance/qualified-teacher-status-qts
-keywords:
-  - Bursary
-  - Bursaries
-  - Scholarship
-  - Undergraduate
-  - Troops to Teachers
-  - Army
-  - Air Force
-  - Navy
-  - Student Finance
-  - Parent
-  - Career
-  - Parents’ Learning Allowance
-  - Childcare Grant
-  - Adult Dependants’ Grant
-  - Disability
-  - Disabled students
-  - Disabled Students’ Allowances
 calls_to_action:
   bursaries:
     name: simple


### PR DESCRIPTION
### Context

We've moved this content higher up - we no longer link to this page but we might have VWO redirects to it. We should remove the page on Thursday, but in the meantime, this means nobody can find it with a search.

### Changes proposed in this pull request

### Guidance to review

