### PR TITLE
Decrease Cypress Test Timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,7 +387,7 @@ jobs:
           ref: refs/heads/master
           repo: get-into-teaching-frontend-tests
           intervalSeconds: 30
-          timeoutSeconds: 1800
+          timeoutSeconds: 300
 
       - name: Check for test failure
         if: steps.wait-for-tests.outputs.conclusion == 'failure'


### PR DESCRIPTION
Time to run Cypress tests in less than 4 minutes normally, so set timeout to 5 minutes.
