### PR TITLE
Make icon sizes explicit

### DIFF
--- a/content/home/_directory.html.erb
+++ b/content/home/_directory.html.erb
@@ -3,6 +3,7 @@
     title: "Life as a teacher",
     icon_image: "icon-school-black.svg",
     icon_alt: "mortarboard icon",
+    icon_size: "40x30",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -16,6 +17,7 @@
     title: "Your training",
     icon_image: "icon-doc-black.svg",
     icon_alt: "icon containing learning materials",
+    icon_size: "40x35",
     classes: "blocks__directory"
   ) do %>
     <ul>
@@ -30,6 +32,7 @@
     title: "Take the next step",
     icon_image: "icon-git-black.svg",
     icon_alt: "site icon logo checkmark",
+    icon_size: "33x33",
     classes: "blocks__directory"
   ) do %>
     <ul>


### PR DESCRIPTION
To avoid content shift the icon sizes should be set explicitly.
