### PR TITLE
Load page-speed-keys for page speed env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	echo ""
 
 APPLICATION_SECRETS=CONTENT-KEYS
+PAGESPEED_SECRETS=PAGE-SPEED-KEYS
 
 .PHONY: development
 development:
@@ -57,3 +58,9 @@ edit-app-secrets: install-fetch-config set-azure-account
 
 print-app-secrets: install-fetch-config set-azure-account 
 	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${APPLICATION_SECRETS}  -f yaml
+
+edit-ps-secrets: install-fetch-config set-azure-account
+    ./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${PAGESPEED_SECRETS} -e -d azure-key-vault-secret:${KEY_VAULT}/${PAGESPEED_SECRETS} -f yaml -c
+
+print-ps-secrets: install-fetch-config set-azure-account 
+    ./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${PAGESPEED_SECRETS}  -f yaml

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -5,7 +5,7 @@ data "azurerm_key_vault" "vault" {
 
 data "azurerm_key_vault_secret" "application" {
   key_vault_id = data.azurerm_key_vault.vault.id
-  name         = "CONTENT-KEYS"
+  name         = var.azure_vault_secret
 }
 
 locals {

--- a/terraform/paas/pagespeed.env.tfvars
+++ b/terraform/paas/pagespeed.env.tfvars
@@ -6,6 +6,7 @@ timeout                   = 1800
 logging                   = 0
 instances                 = 1
 alerts                    = {}
+azure_vault_secret        = "PAGE-SPEED-KEYS"
 azure_key_vault           = "s146t01-kv"
 azure_resource_group      = "s146t01-rg"
 

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -17,6 +17,10 @@ variable "timeout" {
   default = 180
 }
 
+variable "azure_vault_secret" {
+  default = "CONTENT-KEYS"
+}
+
 variable "paas_space" {
   default = "sandbox"
 }


### PR DESCRIPTION
We need a new Rails environment to be able to execute the page speed task on boot; we have a new vault with the keys in and this switches the page speed environment over to use the new keyvault secret.
