### PR TITLE
Deploy from Monday 19 April onwards once happy: Restructure Salaries and Benefits to better serve the majority of users

### DIFF
--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -62,7 +62,7 @@ There are two main ranges for these (TLR 1 and TLR 2), depending on the category
 | TLR 1   | £8,291  | £14,030 |
 | TLR 2   | £2,873  | £7,017  |
 
-Examples of factors that apply to awarding TLRs include impact on educational progress beyond the teacher’s assigned pupils and leading, developing and enhancing the teaching practice of others.
+Factors that apply to awarding TLRs include impact on educational progress beyond the teacher’s assigned pupils. It may also involve leading, developing and enhancing the teaching practice of others.
 
 ### Holidays
 

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -44,8 +44,6 @@ As you progress in your teaching career, it's possible to move up through these 
 | London fringe                 | £26,948 | £42,780 |
 | The rest of England and Wales | £25,714 | £41.604 |
 
-## Teacher benefits
-
 ### Newly qualified teacher benefits
  
 A new 2-year package to support teachers at the start of their career, based on the [Early Career Framework](https://www.gov.uk/government/publications/supporting-early-career-teachers), launches nationally in September 2021.
@@ -84,7 +82,7 @@ The Teachers’ Pension Scheme gives you a regular source of income when you ret
 
 ## Career progression
 
-## Leading practitioners
+### Leading practitioners
 
 A Leading Practitioner is an excellent and highly skilled teacher who consistently demonstrates the highest standards of classroom practice. They share their skills and experience through the coaching, mentoring and induction of teachers, including trainees and newly qualified teachers (NQTs). 
 
@@ -97,7 +95,7 @@ In this role you could earn between £42,402 and £72,480 depending on where you
 | London fringe                 | £43,570 | £65,631 |
 | The rest of England and Wales | £42,402 | £64,461 |
 
-## Headteachers
+### Headteachers
 
 Headteachers lead, motivate and manage staff. In this role you will earn between £47,735 to £125,098 depending on where you teach.
 
@@ -112,7 +110,7 @@ Headteachers lead, motivate and manage staff. In this role you will earn between
 
 Headteachers work with other leadership teachers. The average salary for leadership teachers (excluding headteachers) in 2019 was £54,911.
 
-## Unqualified teachers
+### Unqualified teachers
 
 As an unqualified teacher you could earn between £18,169 and £33,410 depending on where you teach and your level of experience.
 
@@ -122,4 +120,3 @@ As an unqualified teacher you could earn between £18,169 and £33,410 depending
 | Outer London                  | £21,582 | £32,151 |
 | London fringe                 | £19,363 | £29,924 |
 | The rest of England and Wales | £18,169 | £28,735 |
-

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -44,6 +44,46 @@ As you progress in your teaching career, it's possible to move up through these 
 | London fringe                 | £26,948 | £42,780 |
 | The rest of England and Wales | £25,714 | £41.604 |
 
+## Teacher benefits
+
+### Newly qualified teacher benefits
+ 
+A new 2-year package to support teachers at the start of their career, based on the [Early Career Framework](https://www.gov.uk/government/publications/supporting-early-career-teachers), launches nationally in September 2021.
+ 
+The support package includes:
+ 
+* funded 5% time off timetable in the second year of teaching, in addition to the existing 10% in the first year
+* a range of high-quality, freely available curricula and training materials underpinned by the Early Career Framework
+* funded training for mentors of early career teachers
+* funded time for mentors to support early career teachers 
+
+### Teaching and learning responsibility (TLR) payments
+
+If you take on extra ongoing responsibilities in your role, you could get a salary uplift.
+
+There are two main ranges for these (TLR 1 and TLR 2), depending on the category your duties come under:
+
+| Level   | Minimum | Maximum |
+| ------- | -----   | -----   |
+| TLR 1   | £8,291  | £14,030 |
+| TLR 2   | £2,873  | £7,017  |
+
+### Holidays
+
+You'll get more days than people in many other professions. Full-time teachers work for 195 days per year in school.
+
+### Teachers’ Pension Scheme
+
+The Teachers’ Pension Scheme gives you a regular source of income when you retire. It is:
+
+* based on your salary and service rather than investments
+* registered with HM Revenue and Customs - so your contributions are tax-free
+* flexible and allows you to take some of it as a tax-free lump sum
+
+[Find out more from Teachers’ Pensions](https://www.teacherspensions.co.uk/members/new-starter.aspx)
+
+## Career progression
+
 ## Leading practitioners
 
 A Leading Practitioner is an excellent and highly skilled teacher who consistently demonstrates the highest standards of classroom practice. They share their skills and experience through the coaching, mentoring and induction of teachers, including trainees and newly qualified teachers (NQTs). 
@@ -83,40 +123,3 @@ As an unqualified teacher you could earn between £18,169 and £33,410 depending
 | London fringe                 | £19,363 | £29,924 |
 | The rest of England and Wales | £18,169 | £28,735 |
 
-## Teacher benefits
-
-### Newly qualified teacher benefits
- 
-A new 2-year package to support teachers at the start of their career, based on the [Early Career Framework](https://www.gov.uk/government/publications/supporting-early-career-teachers), launches nationally in September 2021.
- 
-The support package includes:
- 
-* funded 5% time off timetable in the second year of teaching, in addition to the existing 10% in the first year
-* a range of high-quality, freely available curricula and training materials underpinned by the Early Career Framework
-* funded training for mentors of early career teachers
-* funded time for mentors to support early career teachers 
-
-### Teaching and learning responsibility (TLR) payments
-
-If you take on extra ongoing responsibilities in your role, you could get a salary uplift.
-
-There are two main ranges for these (TLR 1 and TLR 2), depending on the category your duties come under:
-
-| Level   | Minimum | Maximum |
-| ------- | -----   | -----   |
-| TLR 1   | £8,291  | £14,030 |
-| TLR 2   | £2,873  | £7,017  |
-
-### Holidays
-
-You'll get more days than people in many other professions. Full-time teachers work for 195 days per year in school.
-
-### Teachers’ Pension Scheme
-
-The Teachers’ Pension Scheme gives you a regular source of income when you retire. It is:
-
-* based on your salary and service rather than investments
-* registered with HM Revenue and Customs - so your contributions are tax-free
-* flexible and allows you to take some of it as a tax-free lump sum
-
-[Find out more from Teachers’ Pensions](https://www.teacherspensions.co.uk/members/new-starter.aspx)

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -62,6 +62,8 @@ There are two main ranges for these (TLR 1 and TLR 2), depending on the category
 | TLR 1   | £8,291  | £14,030 |
 | TLR 2   | £2,873  | £7,017  |
 
+Examples of factors that apply to awarding TLRs include impact on educational progress beyond the teacher’s assigned pupils and leading, developing and enhancing the teaching practice of others.
+
 ### Holidays
 
 You'll get more days than people in many other professions. Full-time teachers work for 195 days per year in school.

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -25,10 +25,6 @@ keywords:
   - Pension
 ---
 
-
-
-## Teacher salaries
-
 Schools develop their own pay policies to attract and retain teachers that have the greatest impact on their pupils' learning. What you're paid will be linked to performance, not length of service - meaning your salary can move forward in line with your career.
 
 ## Qualified teachers


### PR DESCRIPTION
### Trello card

https://trello.com/c/kqgBwVpc/1498-re-order-salaries-and-benefits-to-bring-pension-holidays-benefits-relevant-to-newly-qualified-teachers-up-top

### Context

We've taken the approach on other pages (funding your training) to prioritise the top content on the page being for the majority - we put tuition fees there.

This is a ticket to do the same for salaries an benefits. At the moment, we have holidays/pension/ECF at the bottom of the page, below salaries bands for headteachers etc.

We should reorder this (restructure if needed).

### Changes proposed in this pull request

### Guidance to review

