### PR TITLE
Network Policies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,6 +334,14 @@ jobs:
           checkName: Deploy Test
           ref: ${{github.ref}}
 
+      - name: Trigger Test Fix Network Policies
+        uses: benc-uk/workflow-dispatch@v1.1
+        with:
+         repo: DFE-Digital/get-into-teaching-api
+         workflow: Fix Network policies 
+         token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+         inputs: '{"environment": "Test" }'
+         
       - name: Check if QA Deployment has returned with a failure
         if: steps.wait-for-deploy.outputs.conclusion == 'failure'
         run: exit 1


### PR DESCRIPTION
### Problem
Occasionally prometheus looses contact with the Test environment

### Solution
When deploying to Test, trigger the Network policies fix, as the Test environment  is also being monitored

### Review
This does not impact the application
Basically we use private networks between the applications for monitoring, however they become unstable after deployments, so we have a fix script. that was run for production, but not test, now we run it for test too.
