### PR TITLE
Update Disk Quota

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -9,6 +9,7 @@ resource "cloudfoundry_app" "app_application" {
   stopped      = var.application_stopped
   strategy     = var.strategy
   memory       = 1024
+  disk_quota   = 1536
   timeout      = var.timeout
   instances    = var.instances
   dynamic "service_binding" {


### PR DESCRIPTION
Disk quota close to 75% so increasing

Monitoring has shown disk quota to be close to 75% as this application contains the content, a large addition of content may bring quota up too close for comfort, so increasing it from 1GB to 1.5GB 



