### PR TITLE
Merge 19 April: add relevant content from beast page only ways page and delete from b…

### DIFF
--- a/content/guidance/become-a-teacher-in-england.md
+++ b/content/guidance/become-a-teacher-in-england.md
@@ -37,7 +37,7 @@ keywords:
   - Further Education
   - under fives
   - Early years
-  - Early Years Initial Teacher Training 
+  - Early Years Initial Teacher Training
   - EYTT
   - EYITT
   - SKE
@@ -148,100 +148,12 @@ check if you intend to teach students under 18.
 
 If you need further information on financial support options, such as bursaries, scholarships and extra support for parents, carers or people with disabilities, this is available on the [financial support for teaching training guidance page](/funding-your-training).
 
-## Ways to train
-
-### What you’ll need to work as a teacher
-
-To work as a qualified teacher in state schools in England, you’ll need
-Qualified Teacher Status (QTS).
-
-Undergraduate teacher training leading to QTS can take up to 4 years.
-
-Graduate teacher training leading to QTS typically takes one year of full-time study. Some providers offer part-time study, which typically take 2 years.
-
-Once you’ve gained your QTS, you can apply for jobs as a newly-qualified
-teacher (NQT).
-
-NQTs do a further ‘induction programme’ in school as a paid and
-qualified teacher, which allows them to build on their initial teacher
-training.
-
-### What’s the difference between a QTS, a PGCE and PGDE?
-
-QTS allows you to teach as a qualified teacher in state-maintained
-schools and non-maintained special schools in England. It may also allow
-you to teach in other parts of the UK.
-
-There is information available about teaching in [Northern
-Ireland](https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland),
-[Scotland](https://teachinscotland.scot/) and
-[Wales](https://www.discoverteaching.wales/routes-into-teaching/).
-
-A PGCE (postgraduate certificate in education) with QTS gives you an academic qualification as well as QTS. Many PGCE courses include credits that count towards a Master’s degree.
-
-### Find postgraduate teacher training
-
-Use [Find postgraduate teacher training
-courses](https://www.gov.uk/find-postgraduate-teacher-training-courses)
-to search and compare government-approved teacher training providers in
-your area.
-
-All primary and secondary teacher training courses on [Find postgraduate
-teacher training
-courses](https://www.gov.uk/find-postgraduate-teacher-training-courses)
-lead to QTS.
-
-You can also search for ‘further education’ courses leading to a
-post-compulsory education and training qualification (PCET). You do not
-need a degree to apply for courses leading to a PCET.
-
-If you are still exploring options, here are some things to consider.
-
-### Get school experience
-
-Spending time in a school will help you decide if teaching is for you.
-You will learn about different subjects and age groups and get insights
-and information for your personal statement.
-
-The Department for Education helps candidates find placements in school.
-Learn more about [getting school
-experience](https://schoolexperience.education.gov.uk/).
-
-### Science, technology, engineering and mathematics (STEM)
+## Science, technology, engineering and mathematics (STEM)
 
 If your undergraduate degree is in a STEM or STEM-related subject, and
 you are still a student, you can apply for a summer teaching internship.
-For advice, and a list of schools participating in STEM internships,
-visit Get Into Teaching.
 
-### PGCE (or PGDE) with QTS
-
-A PGCE (postgraduate certificate in education) with QTS gives you an
-academic qualification as well as QTS. Many PGCE courses include credits
-that count towards a Master’s degree.
-
-A PGCE may allow you to teach in some other countries. If you’re
-planning to teach overseas, you should always check what’s needed in the
-country you’d like to teach in.
-
-Some providers offer a PGDE (postgraduate diploma in education) with
-QTS. In some cases these courses offer more credits towards a Master’s
-degree than PGCE courses.
-
-Use [Find postgraduate teacher
-training](https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2)
-training to check and learn more about the content and structure of the
-courses on offer.
-
-#### Further education (PGCE or PGDE without QTS)
-
-To teach further education you do not need QTS. Instead you can study
-for a PGCE or PGDE without QTS. These courses are also eligible for
-candidates without a degree.
-
-You can also search for ‘further education’ courses leading to a post-compulsory education and training qualification (PCET). You do not need a degree to apply for courses leading to a PCET.
-
-### Choose an age group
+## Choose an age group
 
 You can train to teach:
 
@@ -302,7 +214,15 @@ Assessment Only is:
   - ideal for graduates with experience of working with children from
     birth age to 5, who meet the Teachers’ Standards (Early Years) and have no need for further training
 
-### Choose a subject
+### Further education
+
+To teach further education you do not need QTS.
+
+Instead you can study for a PGCE or PGDE without QTS. These courses are also eligible for candidates without a degree.
+
+You can [search for further education courses](https://www.gov.uk/find-postgraduate-teacher-training-courses) leading to a post-compulsory education and training qualification (PCET). You do not need a degree to apply for courses leading to a PCET.
+
+## Choose a subject
 
 [View a list of secondary school teaching
 subjects](https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject?l=2)
@@ -317,14 +237,14 @@ Evidence can include:
   - your A level subjects
   - expertise you’ve gained at work
 
-### Subject knowledge enhancement courses
+## Subject knowledge enhancement courses
 
 If you've got the right qualities to teach but need to build up or refresh your subject knowledge, you can complete a subject knowledge enhancement (SKE) course.
 
 These courses are usually available if:
 
 * your degree wasn’t in your chosen subject, but is closely related
-* you studied the subject at A level, but not at degree level 
+* you studied the subject at A level, but not at degree level
 * you have an unrelated degree, but relevant professional knowledge in the subject
 * it's been some time since you used your degree knowledge
 * you studied for a languages degree but need a second language at an acceptable level for teaching in schools
@@ -347,7 +267,7 @@ SKE courses are available in the following subjects:
 
 SKE courses are usually available all over England at universities, schools, or with other organisations. They can be completed before, or alongside your teacher training and are available to study full-time or part-time, classroom-based or on-line. SKE is typically offered in ITT shortage subjects. The [SKE directory](https://www.gov.uk/government/publications/subject-knowledge-enhancement-course-directory) sets out what courses are provided.
 
-### Teaching children with special educational needs and/or disabilities (SEND)
+## Teaching children with special educational needs and/or disabilities (SEND)
 
 Qualified SEND teachers are eligible for an extra payment, on top of their annual salary, of between £2,209 and £4,359 a year.
 
@@ -355,7 +275,7 @@ Use [Find postgraduate teacher
 training](https://www.gov.uk/find-postgraduate-teacher-training-courses)
 to search for training courses that involve working with SEND children.
 
-#### Teaching SEND pupils
+### Teaching SEND pupils
 
 You don’t have to take a SEND specialist course. If you want to be a
 SEND teacher you can apply to teach in a special school if you have:
@@ -364,23 +284,23 @@ SEND teacher you can apply to teach in a special school if you have:
   - experience of managing SEND pupils in your primary or secondary
     school
 
-#### Teaching children with sensory impairments
+### Teaching children with sensory impairments
 
 If you want to teach pupils with hearing, vision or multi-sensory
 impairments, you’ll need a specific qualification.
 
-#### Be a Special Educational Needs Coordinator (SENCo)
+### Be a Special Educational Needs Coordinator (SENCo)
 
 As a SENCo you’ll be responsible for assessing, planning and monitoring the progress of children with SEND. To apply for a job as a SENCo, you’ll need to:
 
   - be a qualified teacher
   - complete the National Award in Special Educational Needs Coordination (NASENCO) when you take up the SENCO post
 
-### Training to teach if you have a disability
+## Training to teach if you have a disability
 
 Teachers with disabilities make valuable contributions both to classrooms and the culture of schools where they work.
 
-#### Your rights
+### Your rights
 
 It is against the law for teacher training providers to discriminate against teacher training candidates with disabilities. Under the Equality Act 2010, providers must make adjustments to help you do a course or go to an interview, providing your requests are reasonable. Examples of support could be:
 
@@ -394,14 +314,14 @@ you might also be able to get support from [Access to
 Work](https://www.gov.uk/access-to-work). This could include a grant to
 help cover the costs of practical support in the workplace.
 
-#### Telling your training provider about your disability when you apply
+### Telling your training provider about your disability when you apply
 
 It’s up to you if you want to tell your training provider about your
 disability. Information you give about your disability is protected under the [Data
 Protection Act
 2018](https://www.gov.uk/data-protection/the-data-protection-act).
 
-#### Useful resources for disabled candidates
+### Useful resources for disabled candidates
 
 * [Get funding help if you're a student with a learning difficulty, health
 problem or
@@ -415,13 +335,13 @@ computers and communication technology for disabled people.
 UK](https://www.disabilityrightsuk.org/adjustments-disabled-students) for
 advice on adjustments for disabled students while studying.
 
-#### Completing a fitness questionnaire
+### Completing a fitness questionnaire
 
 If you’re offered a place on a teacher training course, you may have to
 complete a fitness questionnaire before starting. Training providers
 should only ask relevant questions to make sure you’re able to teach.
 
-### Types of teacher training provider
+## Types of teacher training provider
 
 You can do your teacher training on a course run by a university, an
 individual school, or a partnership of schools (sometimes called a

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -110,7 +110,7 @@ calls_to_action:
       - "Assessment only"
 ---
 
-You need to get Qualified Teacher Status (QTS) to be a primary or secondary teacher in a state school in England.
+You need to get qualified teacher status (QTS) to teach in the majority of schools in England including primary, secondary and special state-funded ‘maintained schools’.
 
 You can get QTS in different ways.
 
@@ -118,7 +118,7 @@ For example, if you already have an undergraduate degree you can do a postgradua
 
 If you do not have a degree, you can do an undergraduate degree which leads to QTS.
 
-Different types of training have different eligibility criteria, [funding options](/funding-your-training) and qualifications.
+Different types of training have different eligibility criteria, [funding options](/funding-your-training) and qualifications. Lots of courses also allow you to study part-time.
 
 You can also [get support to improve your subject knowledge](/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses) to supplement your training.
 
@@ -130,12 +130,18 @@ $pgce$
 
 PGCE programmes combine academic study with a minimum of 24 weeks spent training in schools.
 
-You do not need an academic award such as a PGCE to teach in England, but it may be useful if you want to teach in another country.
+You do not need an academic qualification such as a PGCE to teach in England, but it may be useful if you want to teach in another country.
+
+Many PGCE courses give you credits that count towards a master’s degree.
 
 You can also [get funding](/funding-your-training).
 
+#### Postgraduate Diploma in Education
+
+Some providers offer a Postgraduate Diploma in Education (PGDE) instead of a PGCE. A PGDE sometimes offers more masters credits than a PGCE.
+
 <p class="call-to-action__action">
-  <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find a PGCE <span>course</span></a>
+  <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses">Find a PGCE or PGDE <span>course</span></a>
 </p>
 
 $school-direct-fee-funded$
@@ -210,16 +216,12 @@ You can apply to them directly.
 
 ### Career changers
 
-A [career change into teaching](/guidance/become-a-teacher-in-england#career-changers) will give you the opportunity to use your life, work experience and passion for your subject to inspire young people.
+A career change into teaching will give you the opportunity to use your life, work experience and passion for your subject to inspire young people.
+
+[Now Teach](https://nowteach.org.uk/) and [Transition to Teach](https://www.transitiontoteach.co.uk/) can support you with your career change.
 
 ### Researchers in schools
 
-To go down the [researchers in schools](/guidance/become-a-teacher-in-england#researchers-in-schools-candidates-with-a-doctorate) route you’ll need a doctorate, or be about to receive one, in the subject you want to teach.
-
-You’ll then train over 3 years with a bursary.
+The [researchers in schools](https://thebrilliantclub.org/researchers-in-schools/) offers a route into teaching if you have or are about to get a PHD.
 
 If you have a lot of relevant work experience you could [train and earn a salary](https://thebrilliantclub.org/researchers-in-schools/ris-applicants/ris-training-routes/salary-route/).
-
-### Find out more about ways to train
-
-[Find out more about ways to train](/guidance/become-a-teacher-in-england#ways-to-train) or talk to us to discuss your options.  

--- a/content/ways-to-train.md
+++ b/content/ways-to-train.md
@@ -222,6 +222,6 @@ A career change into teaching will give you the opportunity to use your life, wo
 
 ### Researchers in schools
 
-The [researchers in schools](https://thebrilliantclub.org/researchers-in-schools/) offers a route into teaching if you have or are about to get a PHD.
+[Researchers in schools](https://thebrilliantclub.org/researchers-in-schools/) offers a route into teaching if you have or are about to get a PHD.
 
 If you have a lot of relevant work experience you could [train and earn a salary](https://thebrilliantclub.org/researchers-in-schools/ris-applicants/ris-training-routes/salary-route/).


### PR DESCRIPTION
Add content relating to ways to train from beast page and delete relevant sections from beast page. 

There's still some duplicate content e.g stuff on Now Teach across the 2 pages - but we can address in a separate PR.  

The scope of this PR is simply to be able to remove the 'ways to train' section of the beast page and feel confident content is covered is needed elsewhere.  

