### PR TITLE
Deploy Monday 19 April: Standardise acronym capitalisation

### DIFF
--- a/config/frontmatter.yml
+++ b/config/frontmatter.yml
@@ -1,3 +1,4 @@
+---
 acronyms:
   QTS: Qualified Teacher Status
   NQT: Newly Qualified Teacher
@@ -6,15 +7,15 @@ acronyms:
   EEA: European Economic Area
   DfE: Department for Education
   TLR: Teaching and learning responsibility
-  SCITT: school-centred initial teacher training
-  CAS: confirmation of acceptance for studies
-  ICT: information and communication technologies
+  SCITT: School-Centred Initial Ieacher Iraining
+  CAS: Confirmation of Acceptance for Studies
+  ICT: Information and Communication Technologies
   NPQ: National Professional Qualification
   SKE: subject knowledge enhancement
-  PGCE: postgraduate certificate of education
+  PGCE: Postgraduate Certificate of Education
   BEd: Bachelor of Education degree
   BA: Bachelor of Arts
-  Bsc: Bachelor of Science
-  ITT: initial teacher training
+  BSc: Bachelor of Science
+  ITT: Initial Teacher Training
   EYTS: Early Years Teacher Status
   EYITT: Early Years Initial Teacher Training


### PR DESCRIPTION
Some of our acronyms were capitialised and some weren't. As we're probably going to look at replacing the acronym with some text (on click) it might be worth making it more obvious.