### PR TITLE
Updated a provider to E of England and correct a '.' to ','

### DIFF
--- a/content/assessment-only-providers.md
+++ b/content/assessment-only-providers.md
@@ -36,6 +36,10 @@ providers:
     name: Keith Ferguson
     telephone: 01376 556398
     email: ao@midessexteachertraining.com
+  - header: North Essex Teacher Training (NETT)
+    link: http://www.nett.org.uk/
+    telephone: '01255431949'
+    email: teach@nett.org.uk
   - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
     link: https://www.essexprimaryscitt.co.uk/
     name: Fiona Willett
@@ -152,10 +156,6 @@ providers:
   - header: Middlesex University
     telephone: 020 8411 5555
     email: enquiries@mdx.ac.uk
-  - header: North Essex Teacher Training (NETT)
-    link: http://www.nett.org.uk/
-    telephone: '01255431949'
-    email: teach@nett.org.uk
   - header: St Mary’s University
     link: https://www.stmarys.ac.uk/education-theology-and-leadership/assessment-only-qts.htm
     name: Elizabeth Jackson

--- a/content/assessment-only-providers.md
+++ b/content/assessment-only-providers.md
@@ -36,10 +36,6 @@ providers:
     name: Keith Ferguson
     telephone: 01376 556398
     email: ao@midessexteachertraining.com
-  - header: North Essex Teacher Training (NETT)
-    link: http://www.nett.org.uk/
-    telephone: '01255431949'
-    email: teach@nett.org.uk
   - header: Newlands Spring Primary School Academy Trust (Essex Primary SCITT)
     link: https://www.essexprimaryscitt.co.uk/
     name: Fiona Willett
@@ -50,6 +46,10 @@ providers:
     name: Jacqui Waring
     telephone: 01603 773708
     email: jacqui.waring@ccn.ac.uk
+  - header: North Essex Teacher Training (NETT)
+    link: http://www.nett.org.uk/
+    telephone: '01255431949'
+    email: teach@nett.org.uk
   - header: SAF ITT
     name: Su Bernard
     telephone: 01234 827145

--- a/content/salaries-and-benefits.md
+++ b/content/salaries-and-benefits.md
@@ -38,7 +38,7 @@ As you progress in your teaching career, it's possible to move up through these 
 | Inner London                  | £32,157 | £50,953 |
 | Outer London                  | £29,915 | £45,766 |
 | London fringe                 | £26,948 | £42,780 |
-| The rest of England and Wales | £25,714 | £41.604 |
+| The rest of England and Wales | £25,714 | £41,604 |
 
 ### Newly qualified teacher benefits
  


### PR DESCRIPTION
### Context
Provider request on AO providers to move to East of England. Also bundling in a punctuation change on salaries and benefits page.

### Changes proposed in this pull request
Moved NETT from Greater London to East of England.
Full stop replaces a comma in a salary listing.

### Guidance to review

