### PR TITLE
splitting out provider info

### DIFF
--- a/content/teaching-internship-providers.md
+++ b/content/teaching-internship-providers.md
@@ -134,8 +134,8 @@ providers:
       link: "https://ywtt.org.uk/"
       name: Sarah Barley
       email: sarah.barley@theeducationalliance.org.uk
-    - header: North and West Yorkshire and Calderdale Internships
-      link: "http://www.northernlightstsa.org/"
+    - header: Northern Lights Teaching School
+      link: "https://www.northernlightsscitt.com/our-programmes/teaching-internships1/"
       name: Ginette Hawkins
       email: shine@northernlightstsa.org
     - header: Teach North with Outwood Grange Academies Trust
@@ -146,6 +146,10 @@ providers:
       link: "https://www.sheffieldscitt.org.uk/"
       name: Anna Shirley
       email: ashirley@notredame-high.co.uk
+    - header: Red Kite Teacher Training
+      link: "https://redkiteteachertraining.co.uk/internships-2 "
+      name: Kathy Murdie
+      email: teachertraining@redkitealliance.co.uk
     - header: St Mary's College
       link:  "http://www.schooldirecthull.co.uk"
       name: Kerry Kirby


### PR DESCRIPTION
### Trello card

### Context

Change request came in from provider, to split out their information into two separate tiles. It’s one “TI Provider” but involving two big TSAs - and both schools would like their details sharing – and Claire has confirmed

### Changes proposed in this pull request

Split out North & West Yorkshire and Calderdale Teaching Internships into two the below:

Northern Lights Teaching School | Skipton Girls High School | BD23 1QN | Yorkshire and the Humber | https://www.northernlightsscitt.com/our-programmes/teaching-internships1/ | Ginette Hawkins | Shine@northernslightstsa.org
-- | -- | -- | -- | -- | -- | --
Red Kite Teacher Training | Harrogate Grammar School | HG2 0DZ | Yorkshire and the Humber | https://redkiteteachertraining.co.uk/internships-2 | Kathy Murdie | teachertraining@redkitealliance.co.uk

### Guidance to review

- Check for typos
- Check the information added matches the above
- Check links work
